### PR TITLE
feat: add movie creation endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,13 @@ dist/
 build/
 out/
 .artifacts/
+artifacts/
 .dotnet-cli-home/
 restore*.log
 *.log
 
 # .NET
+packages/
 *.user
 *.rsuser
 *.suo
@@ -50,3 +52,5 @@ docker-compose.override.local.yml
 Thumbs.db
 Desktop.ini
 .DS_Store
+*.tmp
+*.swp

--- a/.specify/inputs/github-issues/11-create-movie.md
+++ b/.specify/inputs/github-issues/11-create-movie.md
@@ -1,0 +1,131 @@
+# GitHub Issue Context
+
+## Source
+
+- Repository: marciomyst/SmartMovieCatalog
+- Issue: #11
+- URL: https://github.com/marciomyst/SmartMovieCatalog/issues/11
+- State: OPEN
+- Created: 05/02/2026 22:05:54
+- Updated: 05/02/2026 22:25:51
+- Milestone: M1 — Core Movie Catalog
+
+## Title
+
+Create movie
+
+## Labels
+
+- type:feature
+- priority:high
+- area:api
+- area:backend
+- area:catalog
+- v1
+
+## Assignees
+
+- marciomyst
+
+
+
+## Issue Body
+
+## Summary
+
+Implement the first real product vertical slice for creating a movie in Smart Movie Catalog.
+
+This issue replaces part of the scaffold direction with an actual movie catalog behavior, while keeping the implementation intentionally simple and aligned with the current Clean Architecture structure.
+
+## Goal
+
+Allow a user to create a movie with basic metadata through the application.
+
+## Scope
+
+- Add a create movie API endpoint.
+- Define explicit request/response DTOs in `SmartMovieCatalog.Contracts`.
+- Add minimal application use case/orchestration in `SmartMovieCatalog.Application`.
+- Add minimal domain model or domain representation only if required by the behavior.
+- Persist or store the movie using the currently accepted persistence approach.
+- Return a stable response containing the created movie identifier and main movie data.
+- Add/update basic frontend flow if the movie creation page already exists or is part of this slice.
+- Update documentation if API contracts or architecture behavior changes.
+
+## Suggested API
+
+```http
+POST /api/movies
+
+{
+  "title": "Central do Brasil",
+  "originalTitle": "Central do Brasil",
+  "releaseYear": 1998,
+  "countryCode": "BR",
+  "originalLanguage": "pt-BR",
+  "genres": ["Drama"],
+  "director": "Walter Salles",
+  "synopsis": "A retired teacher and a young boy travel through Brazil in search of his father.",
+  "durationMinutes": 110,
+  "ageRating": "12"
+}
+```
+
+
+### Acceptance Criteria
+
+- A movie can be created through the API.
+- The endpoint returns `201 Created` when creation succeeds.
+- The response includes the created movie ID.
+- Required fields are validated.
+- Invalid input returns a consistent validation/error response.
+- Business rules do not live directly in controllers.
+- API contracts do not expose persistence models.
+- The implementation respects Clean Architecture dependency direction.
+- No authentication is required in this issue.
+- No Gemini, SignalR, CQRS, Wolverine, RAG, semantic search, or event-driven behavior is introduced.
+
+### Technical Notes
+
+- Keep the first implementation small.
+- Prefer explicit DTOs.
+- Do not introduce speculative abstractions.
+- If persistence is not fully implemented yet, this issue depends on the persistence foundation decision or must use a clearly documented temporary storage approach.
+- Do not leak database-specific details through API responses.
+
+### Out of Scope
+
+- Poster upload.
+- Gemini Vision analysis.
+- SignalR notifications.
+- Authentication/authorization.
+- Semantic search.
+- Advanced duplicate detection.
+- Bulk import.
+- TMDb integration.
+
+## Comments
+
+_No comments_
+
+## Instructions for Spec Kit
+
+Use this GitHub issue as the primary source of truth.
+
+Convert the issue into a Spec Kit feature specification before creating the implementation plan.
+
+Preserve:
+
+- business goal;
+- user stories;
+- acceptance criteria;
+- technical constraints;
+- non-goals;
+- dependencies;
+- open questions.
+
+If information is missing, add it under a clearly marked **Clarifications Needed** section instead of inventing requirements.
+
+If the issue conflicts with existing project documentation, explicitly call out the conflict.
+
+Prefer a small, incremental implementation plan aligned with the repository's existing architecture, folder structure, language, framework, and conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ Do not read, modify, or base analysis on generated/vendor output unless explicit
   - `test:`
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/023-authentication-login-screen/plan.md`.
+Current Spec Kit plan: `specs/011-create-movie/plan.md`.
 
 Before using Spec Kit skills, read `.specify/memory/constitution.md`.
 If the spec, plan, or implementation touches backend, API, contracts, domain,

--- a/backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieEndpoint.cs
+++ b/backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieEndpoint.cs
@@ -1,0 +1,58 @@
+using Microsoft.AspNetCore.Mvc;
+using SmartMovieCatalog.Api.Common;
+using SmartMovieCatalog.Application.Features.Movies;
+using SmartMovieCatalog.Contracts.Movies;
+using Wolverine;
+
+namespace SmartMovieCatalog.Api.Features.Movies.CreateMovie;
+
+public static class CreateMovieEndpoint
+{
+    public static void MapCreateMovie(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/movies", HandleAsync)
+            .WithName("CreateMovie")
+            .WithTags("Movies")
+            .AllowAnonymous()
+            .AddEndpointFilter<ValidationFilter<CreateMovieRequest>>()
+            .Produces<MovieResponse>(StatusCodes.Status201Created)
+            .ProducesValidationProblem(StatusCodes.Status400BadRequest);
+    }
+
+    private static async Task<IResult> HandleAsync(
+        [FromBody] CreateMovieRequest? request,
+        IMessageBus messageBus,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        CreatedMovie createdMovie = await messageBus.InvokeAsync<CreatedMovie>(
+            new CreateMovieCommand(
+                request.Title!,
+                request.OriginalTitle,
+                request.ReleaseYear!.Value,
+                request.CountryCode!,
+                request.OriginalLanguage!,
+                request.Genres,
+                request.Director,
+                request.Synopsis,
+                request.DurationMinutes,
+                request.AgeRating),
+            cancellationToken);
+
+        MovieResponse response = new(
+            createdMovie.Id.ToString(),
+            createdMovie.Title,
+            createdMovie.OriginalTitle,
+            createdMovie.ReleaseYear,
+            createdMovie.CountryCode,
+            createdMovie.OriginalLanguage,
+            createdMovie.Genres,
+            createdMovie.Director,
+            createdMovie.Synopsis,
+            createdMovie.DurationMinutes,
+            createdMovie.AgeRating);
+
+        return Results.Created($"/api/movies/{response.Id}", response);
+    }
+}

--- a/backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieRequestValidator.cs
+++ b/backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieRequestValidator.cs
@@ -1,0 +1,35 @@
+using FluentValidation;
+using SmartMovieCatalog.Contracts.Movies;
+
+namespace SmartMovieCatalog.Api.Features.Movies.CreateMovie;
+
+public sealed class CreateMovieRequestValidator : AbstractValidator<CreateMovieRequest>
+{
+    public CreateMovieRequestValidator()
+    {
+        RuleFor(request => request.Title)
+            .NotEmpty();
+
+        RuleFor(request => request.ReleaseYear)
+            .NotNull()
+            .InclusiveBetween(1888, DateTimeOffset.UtcNow.Year + 1);
+
+        RuleFor(request => request.CountryCode)
+            .NotEmpty()
+            .Must(countryCode => countryCode is not null &&
+                countryCode.Trim().Length == 2 &&
+                countryCode.Trim().All(char.IsLetter))
+            .WithMessage("Country code must contain exactly two letters.");
+
+        RuleFor(request => request.OriginalLanguage)
+            .NotEmpty();
+
+        RuleForEach(request => request.Genres)
+            .Must(genre => !string.IsNullOrWhiteSpace(genre))
+            .WithMessage("Genre must not be empty.");
+
+        RuleFor(request => request.DurationMinutes)
+            .GreaterThan(0)
+            .When(request => request.DurationMinutes.HasValue);
+    }
+}

--- a/backend/src/SmartMovieCatalog.Api/Features/Movies/MoviesEndpoints.cs
+++ b/backend/src/SmartMovieCatalog.Api/Features/Movies/MoviesEndpoints.cs
@@ -1,0 +1,11 @@
+using SmartMovieCatalog.Api.Features.Movies.CreateMovie;
+
+namespace SmartMovieCatalog.Api.Features.Movies;
+
+public static class MoviesEndpoints
+{
+    public static void MapMovieEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapCreateMovie();
+    }
+}

--- a/backend/src/SmartMovieCatalog.Api/Program.cs
+++ b/backend/src/SmartMovieCatalog.Api/Program.cs
@@ -2,8 +2,11 @@ using FluentValidation;
 using SmartMovieCatalog.Api.Common;
 using SmartMovieCatalog.Api.Features.Auth;
 using SmartMovieCatalog.Api.Features.Auth.Authenticate;
+using SmartMovieCatalog.Api.Features.Movies;
+using SmartMovieCatalog.Api.Features.Movies.CreateMovie;
 using SmartMovieCatalog.Application;
 using SmartMovieCatalog.Contracts.Auth;
+using SmartMovieCatalog.Contracts.Movies;
 using SmartMovieCatalog.Infrastructure;
 using SmartMovieCatalog.Infrastructure.Persistence;
 using Wolverine;
@@ -30,6 +33,7 @@ namespace SmartMovieCatalog.Api
             builder.Services.AddApplication();
             builder.Services.AddInfrastructure(builder.Configuration);
             builder.Services.AddScoped<IValidator<AuthenticateRequest>, AuthenticateRequestValidator>();
+            builder.Services.AddScoped<IValidator<CreateMovieRequest>, CreateMovieRequestValidator>();
             builder.Services.AddHealthChecks();
 
             builder.Services.AddOpenApi();
@@ -69,6 +73,7 @@ namespace SmartMovieCatalog.Api
 
 
             app.MapAuthEndpoints();
+            app.MapMovieEndpoints();
 
             app.MapHealthChecks("/health");
 

--- a/backend/src/SmartMovieCatalog.Api/SmartMovieCatalog.Api.http
+++ b/backend/src/SmartMovieCatalog.Api/SmartMovieCatalog.Api.http
@@ -16,3 +16,22 @@ Authorization: Bearer {{access_token}}
 Accept: application/json
 
 ###
+
+POST {{SmartMovieCatalog.Api_HostAddress}}/api/movies
+Content-Type: application/json
+Accept: application/json
+
+{
+  "title": "Central do Brasil",
+  "originalTitle": "Central do Brasil",
+  "releaseYear": 1998,
+  "countryCode": "br",
+  "originalLanguage": "pt-BR",
+  "genres": ["Drama"],
+  "director": "Walter Salles",
+  "synopsis": "A retired teacher and a young boy travel through Brazil in search of his father.",
+  "durationMinutes": 110,
+  "ageRating": "12"
+}
+
+###

--- a/backend/src/SmartMovieCatalog.Application/Abstractions/Persistence/IMovieRepository.cs
+++ b/backend/src/SmartMovieCatalog.Application/Abstractions/Persistence/IMovieRepository.cs
@@ -1,0 +1,10 @@
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Application.Abstractions.Persistence;
+
+public interface IMovieRepository
+{
+    Task AddAsync(Movie movie, CancellationToken cancellationToken);
+
+    Task SaveChangesAsync(CancellationToken cancellationToken);
+}

--- a/backend/src/SmartMovieCatalog.Application/Features/Movies/CreateMovieCommand.cs
+++ b/backend/src/SmartMovieCatalog.Application/Features/Movies/CreateMovieCommand.cs
@@ -1,0 +1,13 @@
+namespace SmartMovieCatalog.Application.Features.Movies;
+
+public sealed record CreateMovieCommand(
+    string Title,
+    string? OriginalTitle,
+    int ReleaseYear,
+    string CountryCode,
+    string OriginalLanguage,
+    IReadOnlyCollection<string>? Genres,
+    string? Director,
+    string? Synopsis,
+    int? DurationMinutes,
+    string? AgeRating);

--- a/backend/src/SmartMovieCatalog.Application/Features/Movies/CreateMovieHandler.cs
+++ b/backend/src/SmartMovieCatalog.Application/Features/Movies/CreateMovieHandler.cs
@@ -1,0 +1,50 @@
+using SmartMovieCatalog.Application.Abstractions.Persistence;
+using SmartMovieCatalog.Application.Abstractions.Time;
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Application.Features.Movies;
+
+public sealed class CreateMovieHandler
+{
+    private readonly IMovieRepository _movieRepository;
+    private readonly IClock _clock;
+
+    public CreateMovieHandler(IMovieRepository movieRepository, IClock clock)
+    {
+        _movieRepository = movieRepository;
+        _clock = clock;
+    }
+
+    public async Task<CreatedMovie> Handle(CreateMovieCommand command, CancellationToken cancellationToken)
+    {
+        Movie movie = Movie.Create(
+            MovieId.New(),
+            command.Title,
+            command.OriginalTitle,
+            command.ReleaseYear,
+            command.CountryCode,
+            command.OriginalLanguage,
+            command.Genres?.Select(MovieGenre.Create),
+            command.Director,
+            command.Synopsis,
+            command.DurationMinutes,
+            command.AgeRating,
+            _clock.UtcNow);
+
+        await _movieRepository.AddAsync(movie, cancellationToken);
+        await _movieRepository.SaveChangesAsync(cancellationToken);
+
+        return new CreatedMovie(
+            movie.Id,
+            movie.Title,
+            movie.OriginalTitle,
+            movie.ReleaseYear,
+            movie.CountryCode,
+            movie.OriginalLanguage,
+            movie.Genres.Select(genre => genre.Name).ToArray(),
+            movie.Director,
+            movie.Synopsis,
+            movie.DurationMinutes,
+            movie.AgeRating);
+    }
+}

--- a/backend/src/SmartMovieCatalog.Application/Features/Movies/CreatedMovie.cs
+++ b/backend/src/SmartMovieCatalog.Application/Features/Movies/CreatedMovie.cs
@@ -1,0 +1,14 @@
+namespace SmartMovieCatalog.Application.Features.Movies;
+
+public sealed record CreatedMovie(
+    Guid Id,
+    string Title,
+    string? OriginalTitle,
+    int ReleaseYear,
+    string CountryCode,
+    string OriginalLanguage,
+    IReadOnlyCollection<string> Genres,
+    string? Director,
+    string? Synopsis,
+    int? DurationMinutes,
+    string? AgeRating);

--- a/backend/src/SmartMovieCatalog.Contracts/Movies/CreateMovieRequest.cs
+++ b/backend/src/SmartMovieCatalog.Contracts/Movies/CreateMovieRequest.cs
@@ -1,0 +1,24 @@
+namespace SmartMovieCatalog.Contracts.Movies;
+
+public sealed record CreateMovieRequest
+{
+    public string? Title { get; init; }
+
+    public string? OriginalTitle { get; init; }
+
+    public int? ReleaseYear { get; init; }
+
+    public string? CountryCode { get; init; }
+
+    public string? OriginalLanguage { get; init; }
+
+    public IReadOnlyCollection<string>? Genres { get; init; }
+
+    public string? Director { get; init; }
+
+    public string? Synopsis { get; init; }
+
+    public int? DurationMinutes { get; init; }
+
+    public string? AgeRating { get; init; }
+}

--- a/backend/src/SmartMovieCatalog.Contracts/Movies/MovieResponse.cs
+++ b/backend/src/SmartMovieCatalog.Contracts/Movies/MovieResponse.cs
@@ -1,0 +1,14 @@
+namespace SmartMovieCatalog.Contracts.Movies;
+
+public sealed record MovieResponse(
+    string Id,
+    string Title,
+    string? OriginalTitle,
+    int ReleaseYear,
+    string CountryCode,
+    string OriginalLanguage,
+    IReadOnlyCollection<string> Genres,
+    string? Director,
+    string? Synopsis,
+    int? DurationMinutes,
+    string? AgeRating);

--- a/backend/src/SmartMovieCatalog.Domain/Movies/Movie.cs
+++ b/backend/src/SmartMovieCatalog.Domain/Movies/Movie.cs
@@ -1,0 +1,156 @@
+using SmartMovieCatalog.Domain.Common;
+
+namespace SmartMovieCatalog.Domain.Movies;
+
+public sealed class Movie : AggregateRoot
+{
+    private readonly List<MovieGenre> _genres = [];
+
+    private Movie()
+    {
+        Title = "Placeholder";
+        ReleaseYear = 1888;
+        CountryCode = "US";
+        OriginalLanguage = "en";
+        CreatedAtUtc = DateTimeOffset.UnixEpoch;
+    }
+
+    private Movie(
+        MovieId id,
+        string title,
+        string? originalTitle,
+        int releaseYear,
+        string countryCode,
+        string originalLanguage,
+        IEnumerable<MovieGenre> genres,
+        string? director,
+        string? synopsis,
+        int? durationMinutes,
+        string? ageRating,
+        DateTimeOffset createdAtUtc)
+    {
+        Id = id.Value;
+        Title = NormalizeRequired(title, nameof(title));
+        OriginalTitle = NormalizeOptional(originalTitle);
+        ReleaseYear = ValidateReleaseYear(releaseYear);
+        CountryCode = NormalizeCountryCode(countryCode);
+        OriginalLanguage = NormalizeRequired(originalLanguage, nameof(originalLanguage));
+        Director = NormalizeOptional(director);
+        Synopsis = NormalizeOptional(synopsis);
+        DurationMinutes = ValidateDuration(durationMinutes);
+        AgeRating = NormalizeOptional(ageRating);
+        CreatedAtUtc = createdAtUtc;
+        ReplaceGenres(genres);
+    }
+
+    public string Title { get; private set; }
+
+    public string? OriginalTitle { get; private set; }
+
+    public int ReleaseYear { get; private set; }
+
+    public string CountryCode { get; private set; }
+
+    public string OriginalLanguage { get; private set; }
+
+    public IReadOnlyCollection<MovieGenre> Genres => _genres.AsReadOnly();
+
+    public string? Director { get; private set; }
+
+    public string? Synopsis { get; private set; }
+
+    public int? DurationMinutes { get; private set; }
+
+    public string? AgeRating { get; private set; }
+
+    public DateTimeOffset CreatedAtUtc { get; private set; }
+
+    public static Movie Create(
+        MovieId id,
+        string title,
+        string? originalTitle,
+        int releaseYear,
+        string countryCode,
+        string originalLanguage,
+        IEnumerable<MovieGenre>? genres,
+        string? director,
+        string? synopsis,
+        int? durationMinutes,
+        string? ageRating,
+        DateTimeOffset createdAtUtc)
+    {
+        return new Movie(
+            id,
+            title,
+            originalTitle,
+            releaseYear,
+            countryCode,
+            originalLanguage,
+            genres ?? [],
+            director,
+            synopsis,
+            durationMinutes,
+            ageRating,
+            createdAtUtc);
+    }
+
+    private static string NormalizeRequired(string? value, string parameterName)
+    {
+        return Guard.AgainstNullOrWhiteSpace(value, parameterName).Trim();
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        string? trimmed = value?.Trim();
+
+        return string.IsNullOrEmpty(trimmed) ? null : trimmed;
+    }
+
+    private static int ValidateReleaseYear(int releaseYear)
+    {
+        int maxReleaseYear = DateTimeOffset.UtcNow.Year + 1;
+        if (releaseYear < 1888 || releaseYear > maxReleaseYear)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(releaseYear),
+                releaseYear,
+                $"Release year must be between 1888 and {maxReleaseYear}.");
+        }
+
+        return releaseYear;
+    }
+
+    private static string NormalizeCountryCode(string? countryCode)
+    {
+        string normalizedCountryCode = NormalizeRequired(countryCode, nameof(countryCode)).ToUpperInvariant();
+        if (normalizedCountryCode.Length != 2 || !normalizedCountryCode.All(char.IsLetter))
+        {
+            throw new ArgumentException("Country code must contain exactly two letters.", nameof(countryCode));
+        }
+
+        return normalizedCountryCode;
+    }
+
+    private static int? ValidateDuration(int? durationMinutes)
+    {
+        if (durationMinutes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(durationMinutes),
+                durationMinutes,
+                "Duration must be positive when supplied.");
+        }
+
+        return durationMinutes;
+    }
+
+    private void ReplaceGenres(IEnumerable<MovieGenre> genres)
+    {
+        MovieGenre[] distinctGenres = genres
+            .Distinct()
+            .ToArray();
+
+        _genres.Clear();
+        _genres.AddRange(distinctGenres);
+    }
+}

--- a/backend/src/SmartMovieCatalog.Domain/Movies/MovieGenre.cs
+++ b/backend/src/SmartMovieCatalog.Domain/Movies/MovieGenre.cs
@@ -1,0 +1,32 @@
+using SmartMovieCatalog.Domain.Common;
+
+namespace SmartMovieCatalog.Domain.Movies;
+
+public sealed class MovieGenre : ValueObject
+{
+    private MovieGenre()
+    {
+        Name = "Unknown";
+    }
+
+    private MovieGenre(string name)
+    {
+        Name = name;
+    }
+
+    public string Name { get; private set; }
+
+    public static MovieGenre Create(string? name)
+    {
+        string normalizedName = Guard.AgainstNullOrWhiteSpace(name, nameof(name)).Trim();
+
+        return new MovieGenre(normalizedName);
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Name;
+    }
+
+    public override string ToString() => Name;
+}

--- a/backend/src/SmartMovieCatalog.Domain/Movies/MovieId.cs
+++ b/backend/src/SmartMovieCatalog.Domain/Movies/MovieId.cs
@@ -1,0 +1,32 @@
+using SmartMovieCatalog.Domain.Common;
+
+namespace SmartMovieCatalog.Domain.Movies;
+
+public sealed class MovieId : ValueObject
+{
+    private MovieId(Guid value)
+    {
+        Value = value;
+    }
+
+    public Guid Value { get; }
+
+    public static MovieId New() => new(Guid.NewGuid());
+
+    public static MovieId From(Guid value)
+    {
+        if (value == Guid.Empty)
+        {
+            throw new ArgumentException("Movie id cannot be empty.", nameof(value));
+        }
+
+        return new MovieId(value);
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Value;
+    }
+
+    public override string ToString() => Value.ToString();
+}

--- a/backend/src/SmartMovieCatalog.Infrastructure/DependencyInjection.cs
+++ b/backend/src/SmartMovieCatalog.Infrastructure/DependencyInjection.cs
@@ -34,6 +34,7 @@ public static class DependencyInjection
 
         services.AddHttpContextAccessor();
         services.AddScoped<IUserRepository, EfUserRepository>();
+        services.AddScoped<IMovieRepository, EfMovieRepository>();
         services.AddSingleton<IPasswordHasher, PasswordHasher>();
         services.AddSingleton<IAccessTokenService, JwtAccessTokenService>();
         services.AddScoped<ICurrentUserPrincipalAccessor, HttpCurrentUserPrincipalAccessor>();

--- a/backend/src/SmartMovieCatalog.Infrastructure/Persistence/Configurations/MovieConfiguration.cs
+++ b/backend/src/SmartMovieCatalog.Infrastructure/Persistence/Configurations/MovieConfiguration.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Infrastructure.Persistence.Configurations;
+
+public sealed class MovieConfiguration : IEntityTypeConfiguration<Movie>
+{
+    public void Configure(EntityTypeBuilder<Movie> builder)
+    {
+        builder.ToTable("Movies");
+
+        builder.HasKey(movie => movie.Id);
+        builder.Ignore(movie => movie.DomainEvents);
+
+        builder.Property(movie => movie.Id)
+            .ValueGeneratedNever();
+
+        builder.Property(movie => movie.Title)
+            .HasMaxLength(300)
+            .IsRequired();
+
+        builder.Property(movie => movie.OriginalTitle)
+            .HasMaxLength(300);
+
+        builder.Property(movie => movie.ReleaseYear)
+            .IsRequired();
+
+        builder.Property(movie => movie.CountryCode)
+            .HasMaxLength(2)
+            .IsRequired();
+
+        builder.Property(movie => movie.OriginalLanguage)
+            .HasMaxLength(35)
+            .IsRequired();
+
+        builder.Property(movie => movie.Director)
+            .HasMaxLength(200);
+
+        builder.Property(movie => movie.Synopsis)
+            .HasMaxLength(4000);
+
+        builder.Property(movie => movie.DurationMinutes);
+
+        builder.Property(movie => movie.AgeRating)
+            .HasMaxLength(32);
+
+        builder.Property(movie => movie.CreatedAtUtc)
+            .IsRequired();
+
+        builder.OwnsMany(
+            movie => movie.Genres,
+            genres =>
+            {
+                genres.ToTable("MovieGenres");
+                genres.WithOwner().HasForeignKey("MovieId");
+                genres.Property<Guid>("MovieId");
+                genres.Property(genre => genre.Name)
+                    .HasMaxLength(100)
+                    .IsRequired();
+                genres.HasKey("MovieId", nameof(MovieGenre.Name));
+            });
+
+        builder.Navigation(movie => movie.Genres)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+    }
+}

--- a/backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs
+++ b/backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs
@@ -1,0 +1,24 @@
+using SmartMovieCatalog.Application.Abstractions.Persistence;
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Infrastructure.Persistence;
+
+public sealed class EfMovieRepository : IMovieRepository
+{
+    private readonly SmartMovieCatalogDbContext _dbContext;
+
+    public EfMovieRepository(SmartMovieCatalogDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task AddAsync(Movie movie, CancellationToken cancellationToken)
+    {
+        await _dbContext.Movies.AddAsync(movie, cancellationToken);
+    }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        return _dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/backend/src/SmartMovieCatalog.Infrastructure/Persistence/Migrations/20260504011757_AddMovies.Designer.cs
+++ b/backend/src/SmartMovieCatalog.Infrastructure/Persistence/Migrations/20260504011757_AddMovies.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using SmartMovieCatalog.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using SmartMovieCatalog.Infrastructure.Persistence;
 namespace SmartMovieCatalog.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SmartMovieCatalogDbContext))]
-    partial class SmartMovieCatalogDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504011757_AddMovies")]
+    partial class AddMovies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/SmartMovieCatalog.Infrastructure/Persistence/Migrations/20260504011757_AddMovies.cs
+++ b/backend/src/SmartMovieCatalog.Infrastructure/Persistence/Migrations/20260504011757_AddMovies.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SmartMovieCatalog.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMovies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Movies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Title = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
+                    OriginalTitle = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+                    ReleaseYear = table.Column<int>(type: "integer", nullable: false),
+                    CountryCode = table.Column<string>(type: "character varying(2)", maxLength: 2, nullable: false),
+                    OriginalLanguage = table.Column<string>(type: "character varying(35)", maxLength: 35, nullable: false),
+                    Director = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: true),
+                    Synopsis = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: true),
+                    DurationMinutes = table.Column<int>(type: "integer", nullable: true),
+                    AgeRating = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    CreatedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Movies", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "MovieGenres",
+                columns: table => new
+                {
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    MovieId = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MovieGenres", x => new { x.MovieId, x.Name });
+                    table.ForeignKey(
+                        name: "FK_MovieGenres_Movies_MovieId",
+                        column: x => x.MovieId,
+                        principalTable: "Movies",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MovieGenres");
+
+            migrationBuilder.DropTable(
+                name: "Movies");
+        }
+    }
+}

--- a/backend/src/SmartMovieCatalog.Infrastructure/Persistence/SmartMovieCatalogDbContext.cs
+++ b/backend/src/SmartMovieCatalog.Infrastructure/Persistence/SmartMovieCatalogDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using SmartMovieCatalog.Domain.Movies;
 using SmartMovieCatalog.Domain.Users;
 
 namespace SmartMovieCatalog.Infrastructure.Persistence;
@@ -11,6 +12,8 @@ public sealed class SmartMovieCatalogDbContext : DbContext
     }
 
     public DbSet<User> Users => Set<User>();
+
+    public DbSet<Movie> Movies => Set<Movie>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointContractTests.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointContractTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using SmartMovieCatalog.Api.Tests.TestSupport;
+using SmartMovieCatalog.Contracts.Movies;
+
+namespace SmartMovieCatalog.Api.Tests.Movies;
+
+public sealed class CreateMovieEndpointContractTests : IClassFixture<SmartMovieCatalogApiFactory>
+{
+    private readonly SmartMovieCatalogApiFactory _factory;
+
+    public CreateMovieEndpointContractTests(SmartMovieCatalogApiFactory factory)
+    {
+        _factory = factory;
+        _factory.Users.Clear();
+        _factory.Movies.Clear();
+    }
+
+    [Fact]
+    public async Task CreateMovie_ResponseUsesContractShape()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/movies",
+            new CreateMovieRequest
+            {
+                Title = "Central do Brasil",
+                ReleaseYear = 1998,
+                CountryCode = "BR",
+                OriginalLanguage = "pt-BR"
+            });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        using JsonDocument document = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement root = document.RootElement;
+        Assert.True(root.TryGetProperty("id", out JsonElement id));
+        Assert.True(Guid.TryParse(id.GetString(), out _));
+        Assert.Equal("Central do Brasil", root.GetProperty("title").GetString());
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("originalTitle").ValueKind);
+        Assert.Equal(1998, root.GetProperty("releaseYear").GetInt32());
+        Assert.Equal("BR", root.GetProperty("countryCode").GetString());
+        Assert.Equal("pt-BR", root.GetProperty("originalLanguage").GetString());
+        Assert.Equal(JsonValueKind.Array, root.GetProperty("genres").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("director").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("synopsis").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("durationMinutes").ValueKind);
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("ageRating").ValueKind);
+    }
+
+    [Fact]
+    public async Task CreateMovie_ReturnsFutureLocationWithoutReadEndpoint()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage createResponse = await client.PostAsJsonAsync(
+            "/api/movies",
+            CreateMovieEndpointTests.ValidRequest());
+
+        MovieResponse? body = await createResponse.Content.ReadFromJsonAsync<MovieResponse>();
+        Assert.NotNull(body);
+        Assert.Equal(new Uri($"/api/movies/{body.Id}", UriKind.Relative), createResponse.Headers.Location);
+
+        HttpResponseMessage readResponse = await client.GetAsync($"/api/movies/{body.Id}");
+        Assert.Equal(HttpStatusCode.NotFound, readResponse.StatusCode);
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointTests.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using System.Net.Http.Json;
+using SmartMovieCatalog.Api.Tests.TestSupport;
+using SmartMovieCatalog.Contracts.Movies;
+
+namespace SmartMovieCatalog.Api.Tests.Movies;
+
+public sealed class CreateMovieEndpointTests : IClassFixture<SmartMovieCatalogApiFactory>
+{
+    private readonly SmartMovieCatalogApiFactory _factory;
+
+    public CreateMovieEndpointTests(SmartMovieCatalogApiFactory factory)
+    {
+        _factory = factory;
+        _factory.Users.Clear();
+        _factory.Movies.Clear();
+    }
+
+    [Fact]
+    public async Task CreateMovie_WithValidRequest_ReturnsCreatedMovie()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/movies",
+            ValidRequest(countryCode: "br"));
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        MovieResponse? body = await response.Content.ReadFromJsonAsync<MovieResponse>();
+        Assert.NotNull(body);
+        Assert.True(Guid.TryParse(body.Id, out _));
+        Assert.Equal("Central do Brasil", body.Title);
+        Assert.Equal("BR", body.CountryCode);
+        Assert.Equal(["Drama"], body.Genres);
+        Assert.Equal(new Uri($"/api/movies/{body.Id}", UriKind.Relative), response.Headers.Location);
+        Assert.Single(_factory.Movies.Movies);
+    }
+
+    [Fact]
+    public async Task CreateMovie_WithoutAuthorizationHeader_DoesNotRequireAuthentication()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync("/api/movies", ValidRequest());
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+
+    public static CreateMovieRequest ValidRequest(string countryCode = "BR")
+    {
+        return new CreateMovieRequest
+        {
+            Title = "Central do Brasil",
+            OriginalTitle = "Central do Brasil",
+            ReleaseYear = 1998,
+            CountryCode = countryCode,
+            OriginalLanguage = "pt-BR",
+            Genres = ["Drama"],
+            Director = "Walter Salles",
+            Synopsis = "A retired teacher and a young boy travel through Brazil in search of his father.",
+            DurationMinutes = 110,
+            AgeRating = "12"
+        };
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointValidationTests.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointValidationTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using SmartMovieCatalog.Api.Tests.TestSupport;
+using SmartMovieCatalog.Contracts.Movies;
+
+namespace SmartMovieCatalog.Api.Tests.Movies;
+
+public sealed class CreateMovieEndpointValidationTests : IClassFixture<SmartMovieCatalogApiFactory>
+{
+    private readonly SmartMovieCatalogApiFactory _factory;
+
+    public CreateMovieEndpointValidationTests(SmartMovieCatalogApiFactory factory)
+    {
+        _factory = factory;
+        _factory.Users.Clear();
+        _factory.Movies.Clear();
+    }
+
+    [Fact]
+    public async Task CreateMovie_WithoutRequestBody_ReturnsValidationProblem()
+    {
+        HttpClient client = _factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, "/api/movies");
+        request.Content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        ValidationProblemDetails? problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.True(problem.Errors.ContainsKey(string.Empty));
+        Assert.Empty(_factory.Movies.Movies);
+    }
+
+    [Fact]
+    public async Task CreateMovie_WithInvalidRequest_ReturnsValidationProblem()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/movies",
+            new CreateMovieRequest
+            {
+                Title = " ",
+                ReleaseYear = 1887,
+                CountryCode = "BRA",
+                OriginalLanguage = " ",
+                Genres = [" "],
+                DurationMinutes = -1
+            });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        ValidationProblemDetails? problem = await response.Content.ReadFromJsonAsync<ValidationProblemDetails>();
+        Assert.NotNull(problem);
+        Assert.Equal(400, problem.Status);
+        Assert.True(problem.Errors.ContainsKey(nameof(CreateMovieRequest.Title)));
+        Assert.True(problem.Errors.ContainsKey(nameof(CreateMovieRequest.ReleaseYear)));
+        Assert.True(problem.Errors.ContainsKey(nameof(CreateMovieRequest.CountryCode)));
+        Assert.True(problem.Errors.ContainsKey(nameof(CreateMovieRequest.OriginalLanguage)));
+        Assert.True(problem.Errors.ContainsKey("Genres[0]"));
+        Assert.True(problem.Errors.ContainsKey(nameof(CreateMovieRequest.DurationMinutes)));
+        Assert.Empty(_factory.Movies.Movies);
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieRequestValidatorTests.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieRequestValidatorTests.cs
@@ -1,0 +1,65 @@
+using FluentValidation.TestHelper;
+using SmartMovieCatalog.Api.Features.Movies.CreateMovie;
+using SmartMovieCatalog.Contracts.Movies;
+
+namespace SmartMovieCatalog.Api.Tests.Movies;
+
+public sealed class CreateMovieRequestValidatorTests
+{
+    private readonly CreateMovieRequestValidator _validator = new();
+
+    [Fact]
+    public async Task Validate_WithValidRequiredFields_Passes()
+    {
+        CreateMovieRequest request = new()
+        {
+            Title = "Central do Brasil",
+            ReleaseYear = 1998,
+            CountryCode = "BR",
+            OriginalLanguage = "pt-BR"
+        };
+
+        TestValidationResult<CreateMovieRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task Validate_WithInvalidFields_ReturnsValidationErrors()
+    {
+        CreateMovieRequest request = new()
+        {
+            Title = " ",
+            ReleaseYear = 1887,
+            CountryCode = "BRA",
+            OriginalLanguage = " ",
+            Genres = ["Drama", " "],
+            DurationMinutes = 0
+        };
+
+        TestValidationResult<CreateMovieRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor(movie => movie.Title);
+        result.ShouldHaveValidationErrorFor(movie => movie.ReleaseYear);
+        result.ShouldHaveValidationErrorFor(movie => movie.CountryCode);
+        result.ShouldHaveValidationErrorFor(movie => movie.OriginalLanguage);
+        result.ShouldHaveValidationErrorFor("Genres[1]");
+        result.ShouldHaveValidationErrorFor(movie => movie.DurationMinutes);
+    }
+
+    [Fact]
+    public async Task Validate_WithReleaseYearAfterNextCalendarYear_ReturnsValidationError()
+    {
+        CreateMovieRequest request = new()
+        {
+            Title = "Future Movie",
+            ReleaseYear = DateTimeOffset.UtcNow.Year + 2,
+            CountryCode = "US",
+            OriginalLanguage = "en"
+        };
+
+        TestValidationResult<CreateMovieRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor(movie => movie.ReleaseYear);
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/FakeMovieRepository.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/FakeMovieRepository.cs
@@ -1,0 +1,28 @@
+using SmartMovieCatalog.Application.Abstractions.Persistence;
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Api.Tests.TestSupport;
+
+public sealed class FakeMovieRepository : IMovieRepository
+{
+    private readonly List<Movie> _movies = [];
+
+    public IReadOnlyCollection<Movie> Movies => _movies.AsReadOnly();
+
+    public void Clear()
+    {
+        _movies.Clear();
+    }
+
+    public Task AddAsync(Movie movie, CancellationToken cancellationToken)
+    {
+        _movies.Add(movie);
+
+        return Task.CompletedTask;
+    }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/SmartMovieCatalogApiFactory.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/SmartMovieCatalogApiFactory.cs
@@ -13,6 +13,8 @@ public sealed class SmartMovieCatalogApiFactory : WebApplicationFactory<Program>
 {
     public FakeUserRepository Users { get; } = new();
 
+    public FakeMovieRepository Movies { get; } = new();
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");
@@ -38,8 +40,10 @@ public sealed class SmartMovieCatalogApiFactory : WebApplicationFactory<Program>
         builder.ConfigureServices(services =>
         {
             services.RemoveAll<IUserRepository>();
+            services.RemoveAll<IMovieRepository>();
             services.RemoveAll<IPasswordHasher>();
             services.AddSingleton<IUserRepository>(Users);
+            services.AddSingleton<IMovieRepository>(Movies);
             services.AddSingleton<IPasswordHasher, TestPasswordHasher>();
         });
     }

--- a/backend/tests/SmartMovieCatalog.Application.Tests/Movies/CreateMovieHandlerTests.cs
+++ b/backend/tests/SmartMovieCatalog.Application.Tests/Movies/CreateMovieHandlerTests.cs
@@ -1,0 +1,39 @@
+using SmartMovieCatalog.Application.Features.Movies;
+using SmartMovieCatalog.Application.Tests.TestSupport;
+
+namespace SmartMovieCatalog.Application.Tests.Movies;
+
+public sealed class CreateMovieHandlerTests
+{
+    [Fact]
+    public async Task Handle_WithValidCommand_PersistsMovieAndReturnsCreatedMovie()
+    {
+        FakeMovieRepository movies = new();
+        FakeClock clock = new()
+        {
+            UtcNow = new DateTimeOffset(2026, 5, 4, 12, 0, 0, TimeSpan.Zero)
+        };
+        CreateMovieHandler handler = new(movies, clock);
+
+        CreatedMovie createdMovie = await handler.Handle(
+            new CreateMovieCommand(
+                " Central do Brasil ",
+                " Central do Brasil ",
+                1998,
+                " br ",
+                " pt-BR ",
+                [" Drama "],
+                " Walter Salles ",
+                " A retired teacher and a young boy travel through Brazil. ",
+                110,
+                " 12 "),
+            CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, createdMovie.Id);
+        Assert.Equal("Central do Brasil", createdMovie.Title);
+        Assert.Equal("BR", createdMovie.CountryCode);
+        Assert.Equal(["Drama"], createdMovie.Genres);
+        Assert.Single(movies.Movies);
+        Assert.Equal(clock.UtcNow, movies.Movies.Single().CreatedAtUtc);
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Application.Tests/TestSupport/FakeMovieRepository.cs
+++ b/backend/tests/SmartMovieCatalog.Application.Tests/TestSupport/FakeMovieRepository.cs
@@ -1,0 +1,23 @@
+using SmartMovieCatalog.Application.Abstractions.Persistence;
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Application.Tests.TestSupport;
+
+public sealed class FakeMovieRepository : IMovieRepository
+{
+    private readonly List<Movie> _movies = [];
+
+    public IReadOnlyCollection<Movie> Movies => _movies.AsReadOnly();
+
+    public Task AddAsync(Movie movie, CancellationToken cancellationToken)
+    {
+        _movies.Add(movie);
+
+        return Task.CompletedTask;
+    }
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Domain.Tests/Movies/MovieTests.cs
+++ b/backend/tests/SmartMovieCatalog.Domain.Tests/Movies/MovieTests.cs
@@ -1,0 +1,65 @@
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Domain.Tests.Movies;
+
+public sealed class MovieTests
+{
+    [Fact]
+    public void Create_WithValidValues_CreatesMovieWithNormalizedData()
+    {
+        DateTimeOffset createdAtUtc = new(2026, 5, 4, 12, 0, 0, TimeSpan.Zero);
+
+        Movie movie = Movie.Create(
+            MovieId.New(),
+            " Central do Brasil ",
+            " Central do Brasil ",
+            1998,
+            " br ",
+            " pt-BR ",
+            [MovieGenre.Create(" Drama "), MovieGenre.Create("Drama")],
+            " Walter Salles ",
+            " A retired teacher and a young boy travel through Brazil. ",
+            110,
+            " 12 ",
+            createdAtUtc);
+
+        Assert.NotEqual(Guid.Empty, movie.Id);
+        Assert.Equal("Central do Brasil", movie.Title);
+        Assert.Equal("Central do Brasil", movie.OriginalTitle);
+        Assert.Equal(1998, movie.ReleaseYear);
+        Assert.Equal("BR", movie.CountryCode);
+        Assert.Equal("pt-BR", movie.OriginalLanguage);
+        Assert.Single(movie.Genres);
+        Assert.Contains(movie.Genres, genre => genre.Name == "Drama");
+        Assert.Equal("Walter Salles", movie.Director);
+        Assert.Equal("A retired teacher and a young boy travel through Brazil.", movie.Synopsis);
+        Assert.Equal(110, movie.DurationMinutes);
+        Assert.Equal("12", movie.AgeRating);
+        Assert.Equal(createdAtUtc, movie.CreatedAtUtc);
+    }
+
+    [Fact]
+    public void Create_WithOnlyRequiredValues_CreatesMovieWithEmptyOptionalData()
+    {
+        Movie movie = Movie.Create(
+            MovieId.New(),
+            "Central do Brasil",
+            originalTitle: null,
+            1998,
+            "BR",
+            "pt-BR",
+            genres: null,
+            director: null,
+            synopsis: null,
+            durationMinutes: null,
+            ageRating: null,
+            DateTimeOffset.UtcNow);
+
+        Assert.Null(movie.OriginalTitle);
+        Assert.Empty(movie.Genres);
+        Assert.Null(movie.Director);
+        Assert.Null(movie.Synopsis);
+        Assert.Null(movie.DurationMinutes);
+        Assert.Null(movie.AgeRating);
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Domain.Tests/Movies/MovieValidationTests.cs
+++ b/backend/tests/SmartMovieCatalog.Domain.Tests/Movies/MovieValidationTests.cs
@@ -1,0 +1,87 @@
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Domain.Tests.Movies;
+
+public sealed class MovieValidationTests
+{
+    [Fact]
+    public void Create_WithEmptyMovieId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => MovieId.From(Guid.Empty));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithBlankTitle_Throws(string? title)
+    {
+        Assert.Throws<ArgumentException>(() => CreateMovie(title: title));
+    }
+
+    [Fact]
+    public void Create_WithReleaseYearBeforeFirstFilmYear_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateMovie(releaseYear: 1887));
+    }
+
+    [Fact]
+    public void Create_WithReleaseYearAfterNextCalendarYear_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateMovie(releaseYear: DateTimeOffset.UtcNow.Year + 2));
+    }
+
+    [Theory]
+    [InlineData("B")]
+    [InlineData("BRA")]
+    [InlineData("B1")]
+    public void Create_WithInvalidCountryCode_Throws(string countryCode)
+    {
+        Assert.Throws<ArgumentException>(() => CreateMovie(countryCode: countryCode));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithBlankOriginalLanguage_Throws(string? originalLanguage)
+    {
+        Assert.Throws<ArgumentException>(() => CreateMovie(originalLanguage: originalLanguage));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_WithNonPositiveDuration_Throws(int durationMinutes)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => CreateMovie(durationMinutes: durationMinutes));
+    }
+
+    [Fact]
+    public void MovieGenre_WithBlankName_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => MovieGenre.Create(" "));
+    }
+
+    private static Movie CreateMovie(
+        string? title = "Central do Brasil",
+        int releaseYear = 1998,
+        string? countryCode = "BR",
+        string? originalLanguage = "pt-BR",
+        int? durationMinutes = null)
+    {
+        return Movie.Create(
+            MovieId.New(),
+            title!,
+            originalTitle: null,
+            releaseYear,
+            countryCode!,
+            originalLanguage!,
+            genres: null,
+            director: null,
+            synopsis: null,
+            durationMinutes,
+            ageRating: null,
+            DateTimeOffset.UtcNow);
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs
+++ b/backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs
@@ -1,0 +1,47 @@
+using Microsoft.EntityFrameworkCore;
+using SmartMovieCatalog.Domain.Movies;
+using SmartMovieCatalog.Infrastructure.Persistence;
+
+namespace SmartMovieCatalog.Infrastructure.Tests.Persistence;
+
+public sealed class EfMovieRepositoryTests
+{
+    [Fact]
+    public async Task AddAsync_SavesMovieWithGenres()
+    {
+        await using SmartMovieCatalogDbContext dbContext = CreateDbContext();
+        EfMovieRepository repository = new(dbContext);
+        Movie movie = Movie.Create(
+            MovieId.New(),
+            " Central do Brasil ",
+            " Central Station ",
+            1998,
+            " br ",
+            " pt-BR ",
+            [MovieGenre.Create(" Drama ")],
+            " Walter Salles ",
+            " Synopsis ",
+            110,
+            " 12 ",
+            new DateTimeOffset(2026, 5, 4, 12, 0, 0, TimeSpan.Zero));
+
+        await repository.AddAsync(movie, CancellationToken.None);
+        await repository.SaveChangesAsync(CancellationToken.None);
+
+        Movie persistedMovie = await dbContext.Movies
+            .Include(savedMovie => savedMovie.Genres)
+            .SingleAsync(savedMovie => savedMovie.Id == movie.Id);
+        Assert.Equal("Central do Brasil", persistedMovie.Title);
+        Assert.Equal("BR", persistedMovie.CountryCode);
+        Assert.Contains(persistedMovie.Genres, genre => genre.Name == "Drama");
+    }
+
+    private static SmartMovieCatalogDbContext CreateDbContext()
+    {
+        DbContextOptions<SmartMovieCatalogDbContext> options = new DbContextOptionsBuilder<SmartMovieCatalogDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new SmartMovieCatalogDbContext(options);
+    }
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,6 +9,7 @@ Current backend endpoints include:
 
 - `POST /api/auth/authenticate`
 - `GET /api/auth/me`
+- `POST /api/movies`
 
 The WeatherForecast scaffold endpoint has been removed.
 
@@ -57,11 +58,73 @@ Returns `200 OK` with:
 
 Missing, malformed, expired, incorrectly signed, missing-user, inactive-user, and removed-user tokens return `401 Unauthorized` as `ProblemDetails`.
 
+## Movie Endpoints
+
+### `POST /api/movies`
+
+Does not require authentication in the first movie catalog slice.
+
+Accepts:
+
+```json
+{
+  "title": "Central do Brasil",
+  "originalTitle": "Central do Brasil",
+  "releaseYear": 1998,
+  "countryCode": "BR",
+  "originalLanguage": "pt-BR",
+  "genres": ["Drama"],
+  "director": "Walter Salles",
+  "synopsis": "A retired teacher and a young boy travel through Brazil in search of his father.",
+  "durationMinutes": 110,
+  "ageRating": "12"
+}
+```
+
+Required fields:
+
+- `title`: non-blank after trimming.
+- `releaseYear`: between `1888` and the next calendar year.
+- `countryCode`: exactly two letters after trimming; normalized to uppercase in the response.
+- `originalLanguage`: non-blank after trimming.
+
+Optional fields:
+
+- `originalTitle`
+- `genres`
+- `director`
+- `synopsis`
+- `durationMinutes`: positive when supplied.
+- `ageRating`
+
+Returns `201 Created` with `Location: /api/movies/{id}` and:
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "title": "Central do Brasil",
+  "originalTitle": "Central do Brasil",
+  "releaseYear": 1998,
+  "countryCode": "BR",
+  "originalLanguage": "pt-BR",
+  "genres": ["Drama"],
+  "director": "Walter Salles",
+  "synopsis": "A retired teacher and a young boy travel through Brazil in search of his father.",
+  "durationMinutes": 110,
+  "ageRating": "12"
+}
+```
+
+Invalid request shape and validation failures return `400 Bad Request` as `ValidationProblemDetails`.
+
+`GET /api/movies/{id}` is not implemented in this slice; the `Location` header reserves the future resource URI.
+
 ## Frontend Consumption
 - The Angular login module calls `POST /api/auth/authenticate` with `email` and `password`.
 - On successful authentication, it calls `GET /api/auth/me` using the returned bearer token.
 - The frontend relies on same-origin `/api` paths. During local `ng serve`, `frontend/src/proxy.conf.js` forwards `/api` to the backend.
 - The frontend maps `400 ValidationProblemDetails` to field-level validation and keeps `401 ProblemDetails` generic to avoid account enumeration.
+- No Angular movie creation flow exists yet.
 
 ## API Design Rules
 - Keep endpoint contracts explicit and stable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,7 +7,7 @@ Smart Movie Catalog / SmartMovieCatalog is a small monorepo with two runtime sur
 - Frontend: Angular 21 in `frontend`.
 
 The backend uses a Clean Architecture project split and integrates the Angular SPA through ASP.NET Core SpaProxy.
-Authentication and persistence are implemented: local email/password authentication issues JWT bearer access tokens, local users are stored with EF Core/PostgreSQL, and backend use cases are dispatched through Wolverine as an in-process CQRS mediator. The Angular SPA includes a login screen that consumes the auth API and keeps the current bearer token in memory.
+Authentication, movie creation, and persistence are implemented: local email/password authentication issues JWT bearer access tokens, local users and movies are stored with EF Core/PostgreSQL, and backend use cases are dispatched through Wolverine as an in-process CQRS mediator. The Angular SPA includes a login screen that consumes the auth API and keeps the current bearer token in memory.
 
 ## Source Of Truth
 - Solution: `SmartMovieCatalog.slnx`
@@ -18,6 +18,7 @@ Authentication and persistence are implemented: local email/password authenticat
 - Contracts project: `backend/src/SmartMovieCatalog.Contracts/SmartMovieCatalog.Contracts.csproj`
 - Backend entry point: `backend/src/SmartMovieCatalog.Api/Program.cs`
 - Backend HTTP features: `backend/src/SmartMovieCatalog.Api/Features`
+- Movie domain model: `backend/src/SmartMovieCatalog.Domain/Movies`
 - Frontend auth module: `frontend/src/app/auth`
 - Frontend package manifest: `frontend/package.json`
 - Frontend visual rules: `frontend/DESIGN.md`

--- a/docs/DOMAIN.md
+++ b/docs/DOMAIN.md
@@ -1,38 +1,50 @@
 # Domain
 
 ## Current Domain Scope
-The product direction is AI-assisted movie cataloging and discovery. The Domain project is still early, but it now contains one implemented backend security aggregate:
+
+The product direction is AI-assisted movie cataloging and discovery. The Domain project is still early, but it now contains these implemented domain concepts:
 
 - `User`: local authentication user aggregate under `backend/src/SmartMovieCatalog.Domain/Users`.
-
-Product-specific movie cataloging aggregates have not been implemented yet.
+- `Movie`: movie catalog record under `backend/src/SmartMovieCatalog.Domain/Movies`.
 
 ## Candidate Domain Concepts
+
 These are candidate concepts, not implemented contracts:
 
-- Movie: catalog item with title, metadata, media assets, and classification data.
 - Catalog: curated collection of movies.
 - User Preference: user-provided or inferred taste profile.
 - Recommendation: ranked movie suggestion generated from catalog and preference signals.
 - AI Analysis: structured output produced by an AI process for a movie or catalog item.
 
+## Movie Domain Decisions
+
+The first persisted movie behavior is `POST /api/movies`.
+
+- Movie identity uses a server-generated GUID.
+- Public API responses expose the movie ID as a JSON string.
+- Uniqueness is by ID only in the first slice; duplicate title/year/country metadata is allowed.
+- Required movie metadata is `title`, `releaseYear`, `countryCode`, and `originalLanguage`.
+- `releaseYear` must be between `1888` and the next calendar year.
+- `countryCode` is exactly two letters and is uppercase-normalized.
+- `originalLanguage` is a trimmed language tag string.
+- Genres are optional, trimmed, non-blank values and are persisted as a normalized child collection.
+- Metadata source is manually supplied by the API caller.
+- Metadata trust level is unverified.
+- Movies are global catalog records with no user owner because authentication and authorization are out of scope for the first create slice.
+- AI analysis, external provider provenance, duplicate detection, update/delete lifecycle, ownership, and authorization are deferred.
+
 ## Domain Rules
+
 - Domain rules must be explicit in code, not hidden in UI logic or infrastructure configuration.
 - Domain model code is organized by aggregate or domain concept folder, as documented in `docs/adr/0006-domain-aggregate-organization.md`.
 - Do not persist or expose AI-generated data without a clear schema and provenance.
 - Keep transport DTOs separate from domain models once domain models exist.
 - Avoid adding domain abstractions before the first real behavior requires them.
 
-## Invariants To Define Before Movie Persistence
-Before adding persisted movie catalog behavior, define at minimum:
-
-- Required movie identity and uniqueness rules.
-- Allowed metadata sources and trust levels.
-- Whether AI analysis can be regenerated, versioned, or manually corrected.
-- Ownership and authorization rules for user-specific data.
-
 ## Non-Goals For Now
-- No product-specific movie cataloging aggregate model yet.
+
 - No domain-layer CQRS abstraction. CQRS command/query dispatch is an Application/API concern documented in `docs/adr/0007-wolverine-cqrs-mediator.md`.
+- No AI analysis schema, regeneration, versioning, or manual correction behavior yet.
+- No user-specific movie ownership rules yet.
 
 Add these only when the implementation requires them or the user explicitly approves an architecture direction.

--- a/specs/011-create-movie/.spec-context.json
+++ b/specs/011-create-movie/.spec-context.json
@@ -1,0 +1,40 @@
+{
+  "workflow": "speckit",
+  "specName": "011-create-movie",
+  "branch": "011-create-movie",
+  "selectedAt": "2026-05-03T23:49:02.489Z",
+  "currentStep": "implement",
+  "status": "implementing",
+  "stepHistory": {
+    "tasks": {
+      "startedAt": "2026-05-03T23:56:02.182Z",
+      "completedAt": "2026-05-03T23:56:02.182Z"
+    },
+    "implement": {
+      "startedAt": "2026-05-03T23:56:02.185Z",
+      "completedAt": null
+    }
+  },
+  "transitions": [
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-03T23:56:02.182Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-03T23:56:02.185Z"
+    }
+  ]
+}

--- a/specs/011-create-movie/contracts/movies.openapi.yaml
+++ b/specs/011-create-movie/contracts/movies.openapi.yaml
@@ -1,0 +1,161 @@
+openapi: 3.0.3
+info:
+  title: SmartMovieCatalog Movies API
+  version: 0.1.0
+paths:
+  /api/movies:
+    post:
+      summary: Create a movie
+      operationId: createMovie
+      tags:
+        - Movies
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateMovieRequest'
+            example:
+              title: Central do Brasil
+              originalTitle: Central do Brasil
+              releaseYear: 1998
+              countryCode: BR
+              originalLanguage: pt-BR
+              genres:
+                - Drama
+              director: Walter Salles
+              synopsis: A retired teacher and a young boy travel through Brazil in search of his father.
+              durationMinutes: 110
+              ageRating: "12"
+      responses:
+        "201":
+          description: Movie created
+          headers:
+            Location:
+              description: Future resource URI for the created movie. The read endpoint is deferred.
+              schema:
+                type: string
+                example: /api/movies/4fd71095-2507-4f92-99c4-06c5d761eb6d
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MovieResponse'
+        "400":
+          description: Validation failure
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/ValidationProblemDetails'
+components:
+  schemas:
+    CreateMovieRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - title
+        - releaseYear
+        - countryCode
+        - originalLanguage
+      properties:
+        title:
+          type: string
+          minLength: 1
+        originalTitle:
+          type: string
+          nullable: true
+        releaseYear:
+          type: integer
+          minimum: 1888
+          description: Must be no later than the next calendar year.
+        countryCode:
+          type: string
+          minLength: 2
+          maxLength: 2
+          pattern: "^[A-Za-z]{2}$"
+          description: Trimmed and normalized to uppercase in responses.
+        originalLanguage:
+          type: string
+          minLength: 1
+          description: Trimmed language tag string.
+        genres:
+          type: array
+          nullable: true
+          items:
+            type: string
+            minLength: 1
+        director:
+          type: string
+          nullable: true
+        synopsis:
+          type: string
+          nullable: true
+        durationMinutes:
+          type: integer
+          nullable: true
+          minimum: 1
+        ageRating:
+          type: string
+          nullable: true
+    MovieResponse:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - releaseYear
+        - countryCode
+        - originalLanguage
+        - genres
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        originalTitle:
+          type: string
+          nullable: true
+        releaseYear:
+          type: integer
+        countryCode:
+          type: string
+          minLength: 2
+          maxLength: 2
+        originalLanguage:
+          type: string
+        genres:
+          type: array
+          items:
+            type: string
+        director:
+          type: string
+          nullable: true
+        synopsis:
+          type: string
+          nullable: true
+        durationMinutes:
+          type: integer
+          nullable: true
+        ageRating:
+          type: string
+          nullable: true
+    ValidationProblemDetails:
+      type: object
+      additionalProperties: true
+      properties:
+        type:
+          type: string
+        title:
+          type: string
+        status:
+          type: integer
+          example: 400
+        traceId:
+          type: string
+        errors:
+          type: object
+          additionalProperties:
+            type: array
+            items:
+              type: string

--- a/specs/011-create-movie/data-model.md
+++ b/specs/011-create-movie/data-model.md
@@ -1,0 +1,114 @@
+# Data Model: Create Movie
+
+## Movie
+
+**Purpose**: Represents a global movie catalog record created from manually supplied, unverified metadata.
+
+**Identity**:
+
+- `id`: server-generated GUID, exposed by API as a JSON string.
+- Uniqueness is by `id` only in this slice.
+- Duplicate title/year/country metadata is allowed.
+
+**Fields**:
+
+| Field | Type | Required | Validation / Normalization |
+|-------|------|----------|----------------------------|
+| `id` | GUID | Yes | Server-generated only |
+| `title` | string | Yes | Trim; non-blank |
+| `originalTitle` | string | No | Trim; null/empty when omitted |
+| `releaseYear` | integer | Yes | `1888` through next calendar year |
+| `countryCode` | string | Yes | Trim; exactly two letters; uppercase-normalized |
+| `originalLanguage` | string | Yes | Trim; non-blank language tag string |
+| `genres` | list of `MovieGenre` | No | Each genre trimmed and non-blank; blank entries rejected |
+| `director` | string | No | Trim; null/empty when omitted |
+| `synopsis` | string | No | Trim; null/empty when omitted |
+| `durationMinutes` | integer | No | Positive when supplied |
+| `ageRating` | string | No | Trim; null/empty when omitted |
+| `createdAtUtc` | datetime offset | Yes | Set server-side if current persistence conventions support it |
+
+**Relationships**:
+
+- `Movie` owns zero or more `MovieGenre` values for persistence.
+- No user owner relationship is added because authentication/authorization is out of scope.
+- No AI analysis, poster, TMDb, catalog collection, recommendation, or search relationship is added.
+
+**Lifecycle**:
+
+- Initial state: created and persisted.
+- Update, delete, publish, moderation, ownership, and AI-analysis lifecycle states are out of scope.
+
+**Trust / Provenance**:
+
+- Metadata source is manually supplied by API caller.
+- Metadata trust level is unverified.
+- No AI provenance or external provider provenance is persisted in this slice.
+
+## MovieGenre
+
+**Purpose**: Normalized genre label owned by a movie.
+
+**Fields**:
+
+| Field | Type | Required | Validation / Normalization |
+|-------|------|----------|----------------------------|
+| `name` | string | Yes | Trim; non-blank |
+
+**Persistence Notes**:
+
+- Persist as a child collection/table associated with `Movie`.
+- Preserve API shape as `genres: string[]`.
+- Do not expose persistence table keys or EF Core implementation details through contracts.
+
+## CreateMovieRequest
+
+**Purpose**: Public API input DTO for `POST /api/movies`.
+
+**Fields**:
+
+| Field | Type | Required |
+|-------|------|----------|
+| `title` | string | Yes |
+| `originalTitle` | string | No |
+| `releaseYear` | integer | Yes |
+| `countryCode` | string | Yes |
+| `originalLanguage` | string | Yes |
+| `genres` | string array | No |
+| `director` | string | No |
+| `synopsis` | string | No |
+| `durationMinutes` | integer | No |
+| `ageRating` | string | No |
+
+## MovieResponse
+
+**Purpose**: Public API output DTO for successful movie creation.
+
+**Fields**:
+
+| Field | Type | Required |
+|-------|------|----------|
+| `id` | string GUID | Yes |
+| `title` | string | Yes |
+| `originalTitle` | string or null | No |
+| `releaseYear` | integer | Yes |
+| `countryCode` | string | Yes |
+| `originalLanguage` | string | Yes |
+| `genres` | string array | Yes, can be empty |
+| `director` | string or null | No |
+| `synopsis` | string or null | No |
+| `durationMinutes` | integer or null | No |
+| `ageRating` | string or null | No |
+
+## Validation Failure Model
+
+Validation failures use ASP.NET Core `ValidationProblemDetails`.
+
+Expected validation failures:
+
+- Missing request body.
+- Blank `title`.
+- Missing or out-of-range `releaseYear`.
+- Blank or non-two-letter `countryCode`.
+- Blank `originalLanguage`.
+- Blank genre entries when `genres` is supplied.
+- Non-positive `durationMinutes` when supplied.

--- a/specs/011-create-movie/plan.md
+++ b/specs/011-create-movie/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Create Movie
+
+**Branch**: `develop` | **Date**: 2026-05-04 | **Spec**: `specs/011-create-movie/spec.md`  
+**Input**: Feature specification from `specs/011-create-movie/spec.md`
+
+**Note**: `.specify/scripts/powershell/setup-plan.ps1 -Json` failed because the repository is currently on `develop`, not a Spec Kit feature branch. This plan explicitly targets `specs/011-create-movie`, generated from GitHub issue #11.
+
+## Summary
+
+Implement a backend-first create movie vertical slice through `POST /api/movies`. The slice adds explicit movie API contracts, request validation, Application-layer command handling through the existing in-process Wolverine mediator, a minimal framework-free Domain movie aggregate, EF Core/PostgreSQL persistence, focused backend tests, and documentation updates. No authentication, frontend UI, AI, SignalR, semantic search, TMDb integration, duplicate detection, or distributed messaging is included.
+
+## Technical Context
+
+**Language/Version**: C# / .NET 10 (`net10.0`), ASP.NET Core 10  
+**Primary Dependencies**: Existing ASP.NET Core Minimal APIs, FluentValidation, WolverineFx as existing in-process mediator, EF Core with Npgsql/PostgreSQL, xUnit backend tests, `Microsoft.AspNetCore.Mvc.Testing` for API tests  
+**Storage**: Existing EF Core/PostgreSQL persistence in `SmartMovieCatalog.Infrastructure`, with migrations under `backend/src/SmartMovieCatalog.Infrastructure/Persistence/Migrations/`  
+**Testing**: Existing backend test projects under `backend/tests`: Domain, Application, Api, and Infrastructure tests using xUnit patterns  
+**Target Platform**: ASP.NET Core API running locally, under test host, and in the existing backend container model  
+**Project Type**: Backend web API inside a backend/frontend monorepo; Angular frontend is out of scope for this slice  
+**Performance Goals**: Single create request should perform one movie insert with no external service calls; no explicit latency SLO is required for this internal first slice  
+**Constraints**: Clean Architecture dependency direction; no new production dependencies unless unavoidable; no committed secrets; no persistence model leakage; no authentication requirement; no new Wolverine infrastructure, transports, background workers, or event-driven behavior  
+**Scale/Scope**: One product endpoint, one movie aggregate, one repository abstraction/implementation, one database migration, focused tests, and docs
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Actual architecture is the source of truth: PASS. Plan follows the observed API/Application/Domain/Infrastructure/Contracts split, Minimal API feature slices, existing EF Core/PostgreSQL persistence, and accepted Wolverine in-process mediator setup.
+- Boundaries stay explicit: PASS. API owns HTTP binding, validation metadata, status codes, and response shaping; Contracts owns public DTOs; Application owns orchestration and persistence abstraction; Domain owns movie invariants; Infrastructure owns EF Core mapping, repository, and migration.
+- Contracts drive cross-boundary work: PASS. API behavior, request/response shape, validation behavior, error behavior, and frontend non-scope are defined before implementation.
+- Security and secret hygiene: PASS. No secrets or secret-bearing configuration are introduced; request data is treated as untrusted; no raw request body logging is planned.
+- Small, verified, reviewable changes: PASS. Scope is a single create endpoint and supporting backend layers, without speculative AI/search/import/auth/frontend behavior.
+- Backend dependency direction: PASS. Domain remains framework-free; Contracts remains independent; Infrastructure depends inward; Api composes and dispatches.
+- Do not invent infrastructure: PASS. Persistence, EF Core/PostgreSQL, Wolverine mediator, and xUnit tests already exist in the codebase. The plan does not add new providers, transports, background workers, or external services.
+- Frontend constitution: PASS by non-scope. No frontend files are planned.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-create-movie/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── movies.openapi.yaml
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+backend/
+├── src/
+│   ├── SmartMovieCatalog.Api/
+│   │   ├── Features/Movies/
+│   │   │   ├── MoviesEndpoints.cs
+│   │   │   └── CreateMovie/
+│   │   │       ├── CreateMovieEndpoint.cs
+│   │   │       └── CreateMovieRequestValidator.cs
+│   │   └── Program.cs
+│   ├── SmartMovieCatalog.Application/
+│   │   ├── Abstractions/Persistence/IMovieRepository.cs
+│   │   └── Features/Movies/
+│   │       ├── CreateMovieCommand.cs
+│   │       ├── CreateMovieHandler.cs
+│   │       └── CreatedMovie.cs
+│   ├── SmartMovieCatalog.Contracts/
+│   │   └── Movies/
+│   │       ├── CreateMovieRequest.cs
+│   │       └── MovieResponse.cs
+│   ├── SmartMovieCatalog.Domain/
+│   │   └── Movies/
+│   │       ├── Movie.cs
+│   │       ├── MovieGenre.cs
+│   │       └── MovieId.cs
+│   └── SmartMovieCatalog.Infrastructure/
+│       └── Persistence/
+│           ├── Configurations/MovieConfiguration.cs
+│           ├── EfMovieRepository.cs
+│           ├── SmartMovieCatalogDbContext.cs
+│           └── Migrations/
+└── tests/
+    ├── SmartMovieCatalog.Domain.Tests/Movies/
+    ├── SmartMovieCatalog.Application.Tests/Movies/
+    ├── SmartMovieCatalog.Api.Tests/Movies/
+    └── SmartMovieCatalog.Infrastructure.Tests/Persistence/
+```
+
+**Structure Decision**: Use the current Clean Architecture backend layout. No frontend structure is added because the spec does not include an existing movie creation page.
+
+## Phase 0: Research
+
+Research output: `specs/011-create-movie/research.md`
+
+Resolved decisions:
+
+- Use explicit Contracts DTOs for `CreateMovieRequest` and `MovieResponse`.
+- Use a minimal `Movie` aggregate under `Domain/Movies` with `MovieId` and genre normalization.
+- Use a server-generated GUID public movie ID returned as a JSON string.
+- Require only `title`, `releaseYear`, `countryCode`, and `originalLanguage`.
+- Validate `releaseYear` from `1888` through the next calendar year.
+- Validate `countryCode` as exactly two letters and uppercase-normalize it; trim and preserve `originalLanguage`.
+- Allow duplicate movie metadata in this first slice.
+- Persist genres as a normalized child collection/table for near-term filtering flexibility without leaking persistence shape through contracts.
+- Return `201 Created` with body plus `Location: /api/movies/{id}`; defer the read endpoint.
+- Use the existing Wolverine in-process mediator only; do not introduce CQRS architecture, transports, retries, sagas, or distributed messaging.
+
+## Phase 1: Design And Contracts
+
+Design artifacts:
+
+- Data model: `specs/011-create-movie/data-model.md`
+- API contract: `specs/011-create-movie/contracts/movies.openapi.yaml`
+- Quickstart: `specs/011-create-movie/quickstart.md`
+
+Contract highlights:
+
+- `POST /api/movies` accepts JSON with required `title`, `releaseYear`, `countryCode`, and `originalLanguage`; optional `originalTitle`, `genres`, `director`, `synopsis`, `durationMinutes`, and `ageRating`.
+- Successful creation returns `201 Created`, `Location: /api/movies/{id}`, and a `MovieResponse`.
+- Validation failures return ASP.NET Core `ValidationProblemDetails` with status `400`.
+- No authorization header is required.
+
+## Post-Design Constitution Check
+
+- Actual architecture is the source of truth: PASS. Design uses existing backend feature-slice, Application handler, Domain aggregate, Infrastructure persistence, and Contracts project boundaries.
+- Boundaries stay explicit: PASS. Public DTOs remain separate from Domain and EF Core models; Domain remains independent of ASP.NET Core, EF Core, Contracts, and Infrastructure.
+- Contracts drive cross-boundary work: PASS. The OpenAPI contract defines request fields, response fields, validation status, and no-auth behavior.
+- Security and secret hygiene: PASS. No secrets are introduced; API input validation and safe error behavior are specified.
+- Small, verified, reviewable changes: PASS. Design is limited to one endpoint and supporting backend layers.
+- Backend dependency direction: PASS. Planned references preserve the current Clean Architecture direction.
+- Do not invent infrastructure: PASS. No new durable architecture decisions require an ADR.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/011-create-movie/quickstart.md
+++ b/specs/011-create-movie/quickstart.md
@@ -1,0 +1,76 @@
+# Quickstart: Create Movie
+
+## Prerequisites
+
+- .NET SDK compatible with `net10.0`.
+- PostgreSQL configuration available through `ConnectionStrings:DefaultConnection` or local user-secrets/environment variables.
+- Existing backend JWT configuration remains required for API startup even though `POST /api/movies` does not require authentication.
+
+## Implementation Verification
+
+Run the full backend solution build after implementation:
+
+```powershell
+dotnet build SmartMovieCatalog.slnx
+```
+
+Run focused backend tests:
+
+```powershell
+dotnet test backend/tests/SmartMovieCatalog.Domain.Tests/SmartMovieCatalog.Domain.Tests.csproj
+dotnet test backend/tests/SmartMovieCatalog.Application.Tests/SmartMovieCatalog.Application.Tests.csproj
+dotnet test backend/tests/SmartMovieCatalog.Api.Tests/SmartMovieCatalog.Api.Tests.csproj
+dotnet test backend/tests/SmartMovieCatalog.Infrastructure.Tests/SmartMovieCatalog.Infrastructure.Tests.csproj
+```
+
+## Manual API Check
+
+Start the API through the repository's normal local workflow, then submit:
+
+```http
+POST /api/movies HTTP/1.1
+Content-Type: application/json
+
+{
+  "title": "Central do Brasil",
+  "originalTitle": "Central do Brasil",
+  "releaseYear": 1998,
+  "countryCode": "br",
+  "originalLanguage": "pt-BR",
+  "genres": ["Drama"],
+  "director": "Walter Salles",
+  "synopsis": "A retired teacher and a young boy travel through Brazil in search of his father.",
+  "durationMinutes": 110,
+  "ageRating": "12"
+}
+```
+
+Expected:
+
+- Status: `201 Created`
+- Header: `Location: /api/movies/{id}`
+- Body includes a GUID string `id`
+- Body has `countryCode` normalized to `BR`
+- No `Authorization` header is required
+
+## Validation Checks
+
+Submit invalid payloads and expect `400 Bad Request` as `ValidationProblemDetails`:
+
+- Missing body.
+- Blank `title`.
+- `releaseYear` less than `1888`.
+- `releaseYear` greater than next calendar year.
+- `countryCode` not exactly two letters.
+- Blank `originalLanguage`.
+- Blank genre value when `genres` is supplied.
+- `durationMinutes` less than or equal to zero.
+
+## Out Of Scope Checks
+
+Implementation should not add:
+
+- Authentication or authorization requirements for `POST /api/movies`.
+- `GET /api/movies/{id}`.
+- Frontend movie creation UI.
+- AI, Gemini, SignalR, semantic search, RAG, TMDb, bulk import, duplicate detection, Wolverine transports, background workers, or new persistence providers.

--- a/specs/011-create-movie/research.md
+++ b/specs/011-create-movie/research.md
@@ -1,0 +1,123 @@
+# Research: Create Movie
+
+## Decision: Use Existing Clean Architecture Feature Slice
+
+**Decision**: Implement `POST /api/movies` as a Minimal API feature slice under `SmartMovieCatalog.Api/Features/Movies/CreateMovie`, dispatching to an Application handler through the existing Wolverine `IMessageBus`.
+
+**Rationale**: `docs/API.md` and current auth endpoints use Minimal API feature slices and existing in-process Wolverine dispatch. Reusing this pattern keeps HTTP concerns in Api and orchestration in Application without introducing a new architectural style.
+
+**Alternatives considered**:
+
+- Directly invoke an Application service from the endpoint: rejected because current API rules prefer Wolverine dispatch.
+- Add controller-based MVC: rejected because current product endpoints are Minimal API feature slices.
+- Add new CQRS/messaging infrastructure: rejected because the issue explicitly forbids new CQRS/Wolverine/event-driven behavior.
+
+## Decision: Define Explicit Public Contracts
+
+**Decision**: Add `CreateMovieRequest` and `MovieResponse` under `SmartMovieCatalog.Contracts/Movies`.
+
+**Rationale**: Product endpoints must use stable DTOs and must not leak persistence entities. Contracts keeps API shape independent from Domain and Infrastructure.
+
+**Alternatives considered**:
+
+- Bind directly to Domain `Movie`: rejected because transport DTOs must remain separate from domain models.
+- Return EF Core entities: rejected by API and constitution rules.
+
+## Decision: Minimal Movie Aggregate
+
+**Decision**: Add a `Movie` aggregate/concept under `SmartMovieCatalog.Domain/Movies` with `MovieId`, normalized required metadata, optional metadata, and genre normalization.
+
+**Rationale**: `docs/DOMAIN.md` requires movie identity, uniqueness, metadata source/trust, AI provenance, and ownership implications before movie persistence. The spec resolves these for the first slice: GUID identity, duplicates allowed, manually supplied unverified metadata, no AI provenance, and no owner.
+
+**Alternatives considered**:
+
+- Store movie as an infrastructure-only persistence entity: rejected because movie identity and invariants are domain concerns.
+- Model posters, AI analysis, ownership, recommendations, or source provenance tables now: rejected as speculative and out of scope.
+
+## Decision: Server-Generated GUID Movie ID
+
+**Decision**: Movie identity uses a server-generated GUID returned as a JSON string.
+
+**Rationale**: Existing auth contracts expose GUID user IDs. GUID IDs avoid sequential database implementation leakage and require no new ID generation scheme.
+
+**Alternatives considered**:
+
+- Sequential numeric IDs: rejected because they expose persistence shape and are less consistent with existing contracts.
+- Opaque arbitrary string IDs: rejected because it adds unnecessary ID format ambiguity.
+
+## Decision: Required Fields And Validation
+
+**Decision**: Require `title`, `releaseYear`, `countryCode`, and `originalLanguage`; treat `originalTitle`, `genres`, `director`, `synopsis`, `durationMinutes`, and `ageRating` as optional.
+
+**Rationale**: The issue asks for basic metadata and an intentionally small implementation. Required title/year/country/language provide enough identity and catalog context without blocking creation on descriptive metadata.
+
+**Alternatives considered**:
+
+- Require `genres`: rejected because genre classification may be unavailable or subjective in the first slice.
+- Require all suggested payload fields: rejected as too strict for a basic create endpoint.
+
+## Decision: Release Year Range
+
+**Decision**: Validate `releaseYear` between `1888` and the next calendar year.
+
+**Rationale**: This range permits early film history and near-future announced releases while rejecting clearly invalid values.
+
+**Alternatives considered**:
+
+- `1900` through current year: rejected because it excludes early films and announced near-future catalog entries.
+- Positive four-digit year: rejected because it admits unrealistic years.
+
+## Decision: Country And Language Validation
+
+**Decision**: Validate `countryCode` as exactly two letters, trim it, and uppercase-normalize it. Trim and preserve `originalLanguage` as a language tag string without strict BCP-47 validation.
+
+**Rationale**: Strict country shape prevents noisy data. Full BCP-47 validation is unnecessary for this first slice and may require more nuance than current scope needs.
+
+**Alternatives considered**:
+
+- Free-form country/language strings: rejected because country data would be too noisy.
+- Strict BCP-47 parser for language: rejected as unnecessary complexity.
+
+## Decision: Duplicate Handling
+
+**Decision**: Allow duplicate movie metadata in the first slice and enforce uniqueness only by movie ID.
+
+**Rationale**: Advanced duplicate detection is explicitly out of scope. Title/year/country duplicates can be legitimate and need a separate product decision.
+
+**Alternatives considered**:
+
+- Unique index on title and release year: rejected because it is a weak global uniqueness rule.
+- Fuzzy duplicate detection: rejected as explicitly out of scope.
+
+## Decision: Genre Persistence Shape
+
+**Decision**: Persist genres as a normalized child collection/table owned by the movie persistence mapping while keeping API contracts as a string array.
+
+**Rationale**: Genres are likely to become filter/search criteria soon. A normalized child collection avoids committing to provider-specific array behavior and keeps the public contract independent from persistence shape.
+
+**Alternatives considered**:
+
+- JSON/serialized string column: rejected because filtering and normalization become harder.
+- PostgreSQL text array: rejected because it is provider-specific and unnecessary for the first model.
+
+## Decision: Created Response
+
+**Decision**: Return `201 Created` with `MovieResponse` body and `Location: /api/movies/{id}` while deferring `GET /api/movies/{id}`.
+
+**Rationale**: This preserves normal create semantics and gives clients a stable future resource URI without expanding the slice into read behavior.
+
+**Alternatives considered**:
+
+- Body only with no `Location`: rejected because API rules prefer a route to the created resource for creates.
+- Add read endpoint now: rejected as scope expansion beyond issue #11.
+
+## Decision: Testing Approach
+
+**Decision**: Add focused tests in existing backend test projects: Domain tests for invariants, Application tests with fake repository, API tests through WebApplicationFactory/fakes, and Infrastructure tests for EF Core mapping.
+
+**Rationale**: Existing backend test projects and auth tests establish this pattern. The feature crosses contracts, domain, application, API, and persistence, so broader backend coverage is justified.
+
+**Alternatives considered**:
+
+- Only API tests: rejected because domain/application/persistence regressions would be under-specified.
+- TestContainers/database-backed tests: rejected because docs explicitly defer that testing cost.

--- a/specs/011-create-movie/spec.md
+++ b/specs/011-create-movie/spec.md
@@ -1,0 +1,155 @@
+# Feature Specification
+
+## Feature Summary
+
+Implement the first real movie catalog vertical slice: creating a movie with basic manually entered metadata through `POST /api/movies`.
+
+The feature adds explicit public API contracts, validation, application orchestration, a minimal movie domain representation, EF Core persistence through the existing infrastructure layer, and a stable `201 Created` response containing the created movie identifier and main movie data. No authentication is required for this issue.
+
+## Clarifications
+
+### Session 2026-05-04
+
+- Q: Which movie fields are required for the first create-movie slice? → A: Required fields are `title`, `releaseYear`, `countryCode`, and `originalLanguage`; all other request fields are optional.
+- Q: What valid range should `releaseYear` use? → A: `releaseYear` must be between `1888` and the next calendar year.
+- Q: What format should the public movie ID use? → A: Movie ID is a server-generated GUID returned as a JSON string.
+- Q: What validation should `countryCode` and `originalLanguage` use? → A: `countryCode` must be two letters; `originalLanguage` is a trimmed language tag string.
+- Q: What `201 Created` response behavior should the endpoint use? → A: Return `201 Created` with the movie body and `Location: /api/movies/{id}`; the read endpoint is deferred.
+
+## Problem Statement
+
+SmartMovieCatalog currently has authentication foundation behavior but no product catalog behavior. The application needs a small, production-shaped movie creation path to replace scaffold direction with an actual catalog use case while preserving Clean Architecture boundaries and current API conventions.
+
+## Goals
+
+- Add a `POST /api/movies` endpoint.
+- Define explicit request and response DTOs in `SmartMovieCatalog.Contracts`.
+- Validate required movie input at the API boundary.
+- Move creation orchestration and business rules out of the endpoint handler.
+- Add a minimal movie domain model or representation required for persisted creation.
+- Persist movies using the current accepted persistence approach.
+- Return `201 Created` with the created movie ID and main movie data.
+- Keep API contracts separate from persistence models.
+- Update API/domain/architecture documentation where behavior or contracts change.
+- Add focused tests for domain/application/API/persistence behavior where existing test structure applies.
+
+## Non-Goals
+
+- Poster upload.
+- Gemini Vision analysis.
+- SignalR notifications.
+- Authentication or authorization.
+- Semantic search.
+- Advanced duplicate detection.
+- Bulk import.
+- TMDb integration.
+- New persistence providers.
+- New external services.
+- New Wolverine transports, distributed messaging, RAG, AI provider behavior, or event-driven processing.
+- Frontend movie creation UI unless an existing movie creation page is found during implementation.
+
+## User Stories
+
+- As an API client, I can submit basic movie metadata and create a movie in the catalog.
+- As an API client, I receive `201 Created` with the created movie ID and movie data when creation succeeds.
+- As an API client, I receive a consistent validation response when required or malformed input is submitted.
+- As a maintainer, I can review the create movie behavior through clear API contracts, application orchestration, domain rules, persistence mapping, and focused tests.
+
+## Functional Requirements
+
+- `POST /api/movies` MUST accept JSON with `title`, `originalTitle`, `releaseYear`, `countryCode`, `originalLanguage`, `genres`, `director`, `synopsis`, `durationMinutes`, and `ageRating`.
+- `POST /api/movies` MUST validate required fields before executing application logic.
+- `title`, `releaseYear`, `countryCode`, and `originalLanguage` MUST be required for movie creation.
+- `originalTitle`, `genres`, `director`, `synopsis`, `durationMinutes`, and `ageRating` MUST be optional for movie creation.
+- `title` MUST be required and non-blank after trimming.
+- `releaseYear` MUST be required and between `1888` and the next calendar year.
+- `countryCode` MUST be required, trimmed, validated as exactly two letters, and normalized to uppercase.
+- `originalLanguage` MUST be required, trimmed, and preserved as a language tag string.
+- `genres` MUST allow one or more non-blank genre names when supplied and MUST avoid persisting blank genre entries.
+- `durationMinutes` MUST be positive when supplied.
+- The endpoint MUST return `400 Bad Request` as `ValidationProblemDetails` for request-shape and field-validation failures.
+- The endpoint MUST dispatch creation through the Application layer instead of placing business rules in the Minimal API handler.
+- The Application layer MUST return a stable created movie result or an expected failure result.
+- The Domain layer MUST define the minimal movie identity and invariant model needed by this behavior.
+- Movie identity MUST use a server-generated GUID that is returned in API responses as a JSON string.
+- The Infrastructure layer MUST persist created movies through the existing EF Core/PostgreSQL persistence approach.
+- Public request and response DTOs MUST live in `SmartMovieCatalog.Contracts` and MUST NOT expose persistence entities.
+- The response MUST include the created movie ID and main movie data.
+- The successful response MUST use `201 Created`.
+- The successful response MUST include a `Location` header with `/api/movies/{id}` even though `GET /api/movies/{id}` is deferred to a later slice.
+- OpenAPI metadata MUST document success and validation responses.
+- Documentation MUST be updated when API contracts, domain constraints, persistence shape, or architecture behavior changes.
+- No authentication MUST be required for this issue.
+- No Gemini, SignalR, CQRS, Wolverine, RAG, semantic search, or event-driven behavior is introduced by this issue.
+
+## Acceptance Criteria
+
+- A movie can be created through the API.
+- The endpoint returns `201 Created` when creation succeeds.
+- The response includes the created movie ID.
+- The successful response includes a `Location` header in the form `/api/movies/{id}`.
+- Required fields are validated.
+- Invalid input returns a consistent validation/error response.
+- Business rules do not live directly in controllers.
+- API contracts do not expose persistence models.
+- The implementation respects Clean Architecture dependency direction.
+- No authentication is required in this issue.
+- No Gemini, SignalR, CQRS, Wolverine, RAG, semantic search, or event-driven behavior is introduced.
+
+## Edge Cases
+
+- Missing request body returns `400 Bad Request` as `ValidationProblemDetails`.
+- Blank `title`, `countryCode`, or `originalLanguage` returns validation errors.
+- Whitespace around string fields is normalized consistently before persistence and response.
+- Invalid `releaseYear` values before `1888` or after the next calendar year return validation errors.
+- `countryCode` values that are not exactly two letters return validation errors.
+- Non-positive `durationMinutes` values return validation errors.
+- Empty or blank genre entries are rejected or normalized consistently.
+- Duplicate movies are allowed in this first slice unless a future feature defines duplicate detection.
+- Database-specific or internal exception details are not exposed through API responses.
+- No user ownership is assigned because authentication and authorization are out of scope.
+
+## Clarifications Needed
+
+None identified.
+
+## Assumptions
+
+- Movie IDs are server-generated GUIDs and stable, using a domain identifier that can be returned as a public JSON string ID.
+- Movie metadata in this issue is manually supplied by the API caller, not imported from TMDb or generated by AI.
+- Metadata trust level is "user supplied / unverified" for this first slice; AI provenance and external-source provenance are out of scope.
+- The first slice does not enforce movie title/year uniqueness because advanced duplicate detection is explicitly out of scope.
+- Created movies are global catalog records with no owner because this issue explicitly requires no authentication.
+- Existing EF Core/PostgreSQL persistence is the accepted persistence approach for this repository.
+- Existing Wolverine in-process dispatch may be used only as the repository's current Application mediator pattern; this issue must not introduce new Wolverine dependencies, transports, distributed messaging, or event-driven behavior.
+- No frontend create movie page currently exists, so frontend work is not part of the planned implementation unless implementation discovers an existing page intended for this slice.
+
+## Dependencies
+
+- Existing ASP.NET Core 10 API project and Minimal API feature-slice structure.
+- Existing `SmartMovieCatalog.Contracts` project for public DTOs.
+- Existing `SmartMovieCatalog.Application` project for use-case orchestration.
+- Existing `SmartMovieCatalog.Domain` project for domain model and invariants.
+- Existing `SmartMovieCatalog.Infrastructure` EF Core/PostgreSQL persistence setup.
+- Existing backend test projects under `backend/tests`.
+- `docs/API.md`, `docs/DOMAIN.md`, `docs/ARCHITECTURE.md`, `docs/SECURITY.md`, and `docs/TESTING.md` for repository rules.
+
+## Risks
+
+- Movie domain constraints are still early; over-modeling the aggregate could create speculative complexity.
+- Under-modeling identity, source trust, and duplicate behavior could violate `docs/DOMAIN.md`; this spec resolves those as first-slice assumptions.
+- Adding persisted movie behavior requires EF Core model and migration changes; migration quality matters even for a small slice.
+- The issue says not to introduce CQRS/Wolverine behavior while current API documentation requires dispatch through Wolverine. The plan treats existing in-process Wolverine usage as an existing architectural pattern, not a new introduction.
+- No authentication means created movie records are not user-owned; a later authenticated catalog feature may need ownership migration or additional fields.
+
+## Out of Scope
+
+- Poster or file upload.
+- AI analysis or Gemini integration.
+- SignalR notifications.
+- Authentication, authorization, route guards, or user ownership.
+- Semantic search, RAG, embeddings, recommendation, or similarity behavior.
+- Duplicate detection beyond allowing records with distinct server-generated IDs.
+- Bulk import.
+- TMDb or other external metadata integration.
+- Frontend implementation unless an existing movie creation page is already part of the codebase.

--- a/specs/011-create-movie/tasks.md
+++ b/specs/011-create-movie/tasks.md
@@ -1,0 +1,226 @@
+# Tasks: Create Movie
+
+**Input**: Design documents from `specs/011-create-movie/`  
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/movies.openapi.yaml`, `quickstart.md`  
+**Prerequisite Note**: `.specify/scripts/powershell/check-prerequisites.ps1 -Json` failed because the current branch is `develop`, not a Spec Kit feature branch. These tasks target the explicit feature directory `specs/011-create-movie`.  
+**Tests**: Included because the specification requires focused backend tests for domain, application, API, and persistence behavior.  
+**Organization**: Tasks are grouped by independently testable user story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files and has no dependency on incomplete tasks in the same phase
+- **[Story]**: User story label for traceability
+- Every task includes exact file paths
+
+## User Stories
+
+- **US1 (P1)**: As an API client, I can submit basic movie metadata and create a movie in the catalog.
+- **US2 (P2)**: As an API client, I receive a consistent validation response when required or malformed input is submitted.
+- **US3 (P3)**: As a maintainer, I can review the create movie behavior through clear contracts, architecture boundaries, persistence mapping, tests, and documentation.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare source and test locations for the backend create movie slice.
+
+- [X] T001 Create movie contracts folder in `backend/src/SmartMovieCatalog.Contracts/Movies/`
+- [X] T002 Create movie API feature folders in `backend/src/SmartMovieCatalog.Api/Features/Movies/` and `backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/`
+- [X] T003 Create movie application feature folder in `backend/src/SmartMovieCatalog.Application/Features/Movies/`
+- [X] T004 Create movie domain folder in `backend/src/SmartMovieCatalog.Domain/Movies/`
+- [X] T005 Create movie test folders in `backend/tests/SmartMovieCatalog.Domain.Tests/Movies/`, `backend/tests/SmartMovieCatalog.Application.Tests/Movies/`, `backend/tests/SmartMovieCatalog.Api.Tests/Movies/`, and `backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Define shared contracts, domain model, repository abstraction, and persistence mapping required by all user stories.
+
+**Critical**: No user story work can begin until this phase is complete.
+
+- [X] T006 [P] Add `CreateMovieRequest` DTO matching `specs/011-create-movie/contracts/movies.openapi.yaml` in `backend/src/SmartMovieCatalog.Contracts/Movies/CreateMovieRequest.cs`
+- [X] T007 [P] Add `MovieResponse` DTO matching `specs/011-create-movie/contracts/movies.openapi.yaml` in `backend/src/SmartMovieCatalog.Contracts/Movies/MovieResponse.cs`
+- [X] T008 [P] Add server-generated GUID `MovieId` value object in `backend/src/SmartMovieCatalog.Domain/Movies/MovieId.cs`
+- [X] T009 [P] Add trimmed non-blank `MovieGenre` value object in `backend/src/SmartMovieCatalog.Domain/Movies/MovieGenre.cs`
+- [X] T010 Add `Movie` aggregate with required fields, optional metadata, duplicate-allowed identity, and normalization rules in `backend/src/SmartMovieCatalog.Domain/Movies/Movie.cs`
+- [X] T011 Add `IMovieRepository` create abstraction in `backend/src/SmartMovieCatalog.Application/Abstractions/Persistence/IMovieRepository.cs`
+- [X] T012 Add EF Core `MovieConfiguration` with normalized genre child collection mapping in `backend/src/SmartMovieCatalog.Infrastructure/Persistence/Configurations/MovieConfiguration.cs`
+- [X] T013 Add `Movies` DbSet to `backend/src/SmartMovieCatalog.Infrastructure/Persistence/SmartMovieCatalogDbContext.cs`
+- [X] T014 Add `EfMovieRepository` implementation in `backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs`
+- [X] T015 Register `IMovieRepository` to `EfMovieRepository` in `backend/src/SmartMovieCatalog.Infrastructure/DependencyInjection.cs`
+
+**Checkpoint**: Foundation ready. Contracts, Domain movie model, repository abstraction, EF mapping, DbSet, repository implementation, and DI are in place.
+
+---
+
+## Phase 3: User Story 1 - Create Movie Successfully (Priority: P1) MVP
+
+**Goal**: Valid movie metadata can be submitted to `POST /api/movies` without authentication and persisted, returning `201 Created`, a GUID movie ID, a normalized response body, and `Location: /api/movies/{id}`.
+
+**Independent Test**: Submit the `quickstart.md` valid payload with lowercase `countryCode`; expect `201 Created`, `Location: /api/movies/{id}`, a GUID string `id`, `countryCode: "BR"`, no auth requirement, and persisted movie data with normalized genres.
+
+### Tests for User Story 1
+
+- [X] T016 [P] [US1] Add domain tests for valid movie creation, GUID identity, field trimming, country uppercase normalization, and optional metadata in `backend/tests/SmartMovieCatalog.Domain.Tests/Movies/MovieTests.cs`
+- [X] T017 [P] [US1] Add application fake movie repository in `backend/tests/SmartMovieCatalog.Application.Tests/TestSupport/FakeMovieRepository.cs`
+- [X] T018 [US1] Add application tests for successful create movie command using `IClock` and fake repository in `backend/tests/SmartMovieCatalog.Application.Tests/Movies/CreateMovieHandlerTests.cs`
+- [X] T019 [P] [US1] Add API fake movie repository support in `backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/FakeMovieRepository.cs`
+- [X] T020 [US1] Update API test factory to replace `IMovieRepository` in `backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/SmartMovieCatalogApiFactory.cs`
+- [X] T021 [US1] Add API test for valid `POST /api/movies` returning `201 Created`, `Location`, GUID `id`, and no auth requirement in `backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointTests.cs`
+- [X] T022 [US1] Add infrastructure persistence test for saving and reading a movie with normalized genres in `backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs`
+
+### Implementation for User Story 1
+
+- [X] T023 [US1] Add `CreateMovieCommand` with required and optional metadata fields in `backend/src/SmartMovieCatalog.Application/Features/Movies/CreateMovieCommand.cs`
+- [X] T024 [US1] Add `CreatedMovie` result model mirroring `MovieResponse` data in `backend/src/SmartMovieCatalog.Application/Features/Movies/CreatedMovie.cs`
+- [X] T025 [US1] Add `CreateMovieHandler` that creates a `Movie`, uses `IClock` for `createdAtUtc`, and persists through `IMovieRepository` in `backend/src/SmartMovieCatalog.Application/Features/Movies/CreateMovieHandler.cs`
+- [X] T026 [US1] Add `MoviesEndpoints` mapper in `backend/src/SmartMovieCatalog.Api/Features/Movies/MoviesEndpoints.cs`
+- [X] T027 [US1] Add `CreateMovieEndpoint` that dispatches through `IMessageBus.InvokeAsync` and returns `Results.Created($"/api/movies/{id}", body)` in `backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieEndpoint.cs`
+- [X] T028 [US1] Map movie endpoints in the API host in `backend/src/SmartMovieCatalog.Api/Program.cs`
+- [X] T029 [US1] Generate EF Core migration for `Movies` and normalized movie genres under `backend/src/SmartMovieCatalog.Infrastructure/Persistence/Migrations/`
+
+**Checkpoint**: User Story 1 is functional and testable independently as the MVP.
+
+---
+
+## Phase 4: User Story 2 - Validate Invalid Movie Input (Priority: P2)
+
+**Goal**: Invalid or incomplete movie input returns `400 Bad Request` as ASP.NET Core `ValidationProblemDetails` before application logic runs.
+
+**Independent Test**: Submit missing body, blank `title`, missing/out-of-range `releaseYear`, invalid `countryCode`, blank `originalLanguage`, blank genre entries, and non-positive `durationMinutes`; expect field-level validation errors and no persisted movie.
+
+### Tests for User Story 2
+
+- [X] T030 [P] [US2] Add validator tests for required fields, `1888` through next-calendar-year release range, two-letter country code, blank language, blank genres, and positive duration in `backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieRequestValidatorTests.cs`
+- [X] T031 [US2] Add API tests for missing body and validation failures returning `ValidationProblemDetails` in `backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointValidationTests.cs`
+- [X] T032 [P] [US2] Add domain tests for invalid movie invariants that must not be bypassed by Application code in `backend/tests/SmartMovieCatalog.Domain.Tests/Movies/MovieValidationTests.cs`
+
+### Implementation for User Story 2
+
+- [X] T033 [US2] Add `CreateMovieRequestValidator` with OpenAPI-aligned validation rules in `backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieRequestValidator.cs`
+- [X] T034 [US2] Register `IValidator<CreateMovieRequest>` in `backend/src/SmartMovieCatalog.Api/Program.cs`
+- [X] T035 [US2] Add `ValidationFilter<CreateMovieRequest>` and validation response metadata to `backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieEndpoint.cs`
+- [X] T036 [US2] Ensure expected create movie failures map to safe `ValidationProblemDetails` or `ProblemDetails` without internal details in `backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieEndpoint.cs`
+
+**Checkpoint**: User Story 2 is functional and does not introduce authentication, frontend behavior, or external dependencies.
+
+---
+
+## Phase 5: User Story 3 - Maintainable Contracts, Persistence, And Documentation (Priority: P3)
+
+**Goal**: The implementation is reviewable through explicit contracts, Clean Architecture boundaries, normalized persistence mapping, focused tests, quickstart checks, and updated docs.
+
+**Independent Test**: Review source paths and docs to confirm contracts do not expose persistence models, business logic is outside the API handler, `GET /api/movies/{id}` is not added, normalized genre persistence is documented, and backend tests/builds pass.
+
+### Tests for User Story 3
+
+- [X] T037 [P] [US3] Add contract-shape assertions for `MovieResponse` JSON serialization and nullable optional fields in `backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointContractTests.cs`
+- [X] T038 [US3] Add API contract test that `POST /api/movies` returns `Location: /api/movies/{id}` without adding a `GET /api/movies/{id}` endpoint in `backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointContractTests.cs`
+- [X] T039 [US3] Run focused backend test projects referenced by `specs/011-create-movie/quickstart.md` using `backend/tests/SmartMovieCatalog.Domain.Tests/SmartMovieCatalog.Domain.Tests.csproj`, `backend/tests/SmartMovieCatalog.Application.Tests/SmartMovieCatalog.Application.Tests.csproj`, `backend/tests/SmartMovieCatalog.Api.Tests/SmartMovieCatalog.Api.Tests.csproj`, and `backend/tests/SmartMovieCatalog.Infrastructure.Tests/SmartMovieCatalog.Infrastructure.Tests.csproj`
+
+### Implementation for User Story 3
+
+- [X] T040 [US3] Update movie endpoint documentation in `docs/API.md`
+- [X] T041 [US3] Update initial movie domain decisions for identity, uniqueness, trust, ownership, and AI provenance in `docs/DOMAIN.md`
+- [X] T042 [US3] Update architecture current state for movie persistence only if implemented boundaries change documented behavior in `docs/ARCHITECTURE.md`
+- [X] T043 [US3] Add or update manual HTTP example for `POST /api/movies` in `backend/src/SmartMovieCatalog.Api/SmartMovieCatalog.Api.http`
+- [X] T044 [US3] Verify public DTOs do not reference Domain, Infrastructure, EF Core, or provider-specific types in `backend/src/SmartMovieCatalog.Contracts/Movies/`
+
+**Checkpoint**: User Story 3 makes the slice maintainable and reviewable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final verification, cleanup, and safety checks across the create movie slice.
+
+- [X] T045 [P] Review naming and nullable annotations across `backend/src/SmartMovieCatalog.Contracts/Movies/`, `backend/src/SmartMovieCatalog.Application/Features/Movies/`, `backend/src/SmartMovieCatalog.Domain/Movies/`, and `backend/src/SmartMovieCatalog.Infrastructure/Persistence/`
+- [X] T046 [P] Review logging and error handling to avoid raw request bodies, synopsis text, EF Core details, connection strings, and internal exception details in `backend/src/SmartMovieCatalog.Api/Features/Movies/CreateMovie/CreateMovieEndpoint.cs`
+- [X] T047 Verify quickstart valid and invalid payload scenarios from `specs/011-create-movie/quickstart.md`
+- [X] T048 Run `dotnet build SmartMovieCatalog.slnx` against `SmartMovieCatalog.slnx`
+- [X] T049 Review `git diff` for unrelated changes across `backend/src/`, `backend/tests/`, `docs/`, and `specs/011-create-movie/tasks.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 Setup**: No dependencies.
+- **Phase 2 Foundational**: Depends on Phase 1 and blocks all user stories.
+- **Phase 3 US1**: Depends on Phase 2 and delivers the MVP.
+- **Phase 4 US2**: Depends on Phase 2 and integrates with the endpoint from US1.
+- **Phase 5 US3**: Depends on the implemented contract/API/domain/persistence shape from US1 and US2.
+- **Phase 6 Polish**: Depends on selected user stories being complete.
+
+### User Story Dependencies
+
+- **US1 Create Movie Successfully**: MVP; can start after Phase 2.
+- **US2 Validate Invalid Movie Input**: Can start after Phase 2; endpoint integration is simplest after T027 creates the endpoint.
+- **US3 Maintainable Contracts, Persistence, And Documentation**: Depends on final implementation shape from US1 and US2.
+
+### Within Each User Story
+
+- Tests should be written first and fail before implementation where practical.
+- Domain and contract models precede Application handlers.
+- Application handlers precede API endpoint wiring.
+- EF Core mapping and repository registration precede persistence-backed endpoint success.
+- Documentation follows the implemented public behavior and durable domain decisions.
+
+## Parallel Opportunities
+
+- T006, T007, T008, and T009 can run in parallel after setup.
+- T016, T017, T019, and T022 can run in parallel once foundational files exist.
+- T030 and T032 can run in parallel for validation behavior.
+- T040, T041, and T042 can run in parallel after implementation behavior is stable.
+- T045 and T046 can run in parallel during final polish.
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T016 [P] [US1] Add domain tests for valid movie creation, GUID identity, field trimming, country uppercase normalization, and optional metadata in backend/tests/SmartMovieCatalog.Domain.Tests/Movies/MovieTests.cs"
+Task: "T017 [P] [US1] Add application fake movie repository in backend/tests/SmartMovieCatalog.Application.Tests/TestSupport/FakeMovieRepository.cs"
+Task: "T019 [P] [US1] Add API fake movie repository support in backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/FakeMovieRepository.cs"
+Task: "T022 [US1] Add infrastructure persistence test for saving and reading a movie with normalized genres in backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "T030 [P] [US2] Add validator tests for required fields, 1888 through next-calendar-year release range, two-letter country code, blank language, blank genres, and positive duration in backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieRequestValidatorTests.cs"
+Task: "T032 [P] [US2] Add domain tests for invalid movie invariants that must not be bypassed by Application code in backend/tests/SmartMovieCatalog.Domain.Tests/Movies/MovieValidationTests.cs"
+```
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1.
+2. Complete Phase 2.
+3. Complete Phase 3 for US1.
+4. Validate that `POST /api/movies` returns `201 Created`, a GUID `id`, normalized `countryCode`, and `Location: /api/movies/{id}` for the quickstart payload.
+5. Stop and review before expanding validation and documentation if a smaller review slice is desired.
+
+### Incremental Delivery
+
+1. Deliver US1 to create and persist movies.
+2. Deliver US2 to harden invalid-input behavior.
+3. Deliver US3 to finalize documentation, contract checks, and architecture reviewability.
+4. Complete polish and full solution build.
+
+### Verification Commands
+
+```powershell
+dotnet test backend/tests/SmartMovieCatalog.Domain.Tests/SmartMovieCatalog.Domain.Tests.csproj
+dotnet test backend/tests/SmartMovieCatalog.Application.Tests/SmartMovieCatalog.Application.Tests.csproj
+dotnet test backend/tests/SmartMovieCatalog.Api.Tests/SmartMovieCatalog.Api.Tests.csproj
+dotnet test backend/tests/SmartMovieCatalog.Infrastructure.Tests/SmartMovieCatalog.Infrastructure.Tests.csproj
+dotnet build SmartMovieCatalog.slnx
+```
+
+## Notes
+
+- Do not add frontend code unless an existing movie creation page is discovered and explicitly pulled into scope.
+- Do not introduce authentication, authorization, AI, SignalR, semantic search, RAG, TMDb, bulk import, duplicate detection, distributed messaging, Wolverine transports, background workers, or new persistence providers.
+- Existing Wolverine in-process dispatch is allowed only as the current Application mediator pattern; do not add new Wolverine architecture.
+- Keep generated/vendor paths out of scope: `node_modules/`, `bin/`, `obj/`, `dist/`, `.vs/`, `.angular/cache/`.


### PR DESCRIPTION
## Summary

Implements the first movie catalog vertical slice for issue #11.

- Adds `POST /api/movies` with explicit request/response contracts.
- Adds a minimal Movie domain model, Application command handler, EF Core persistence, and migration.
- Adds validation for required fields, release year range, country code, genres, and duration.
- Updates API/domain/architecture docs and Spec Kit artifacts.

## Impact

- API clients can create global movie catalog records without authentication for this slice.
- Successful creates return `201 Created`, `Location: /api/movies/{id}`, and a stable movie response body.
- Invalid input returns ASP.NET Core `ValidationProblemDetails`.

## Validation

- `dotnet test backend/tests/SmartMovieCatalog.Domain.Tests/SmartMovieCatalog.Domain.Tests.csproj`
- `dotnet test backend/tests/SmartMovieCatalog.Application.Tests/SmartMovieCatalog.Application.Tests.csproj`
- `dotnet test backend/tests/SmartMovieCatalog.Api.Tests/SmartMovieCatalog.Api.Tests.csproj`
- `dotnet test backend/tests/SmartMovieCatalog.Infrastructure.Tests/SmartMovieCatalog.Infrastructure.Tests.csproj`
- `dotnet build SmartMovieCatalog.slnx`

## Notes

- `GET /api/movies/{id}` remains out of scope.
- Frontend movie creation UI remains out of scope.
- Existing unrelated local edits under `specs/023-authentication-login-screen/*` were not included.

Closes #11