### PR TITLE
[codex] add catalog page

### DIFF
--- a/.specify/inputs/github-issues/18-catalog-page.md
+++ b/.specify/inputs/github-issues/18-catalog-page.md
@@ -1,0 +1,174 @@
+﻿# GitHub Issue Context
+
+## Source
+
+- Repository: marciomyst/SmartMovieCatalog
+- Issue: #18
+- URL: https://github.com/marciomyst/SmartMovieCatalog/issues/18
+- State: OPEN
+- Created: 2026-05-02T23:34:28Z
+- Updated: 2026-05-02T23:34:28Z
+- Milestone: M1 — Core Movie Catalog
+
+## Title
+
+Catalog page
+
+## Labels
+
+- type:feature
+- priority:high
+- area:frontend
+- area:catalog
+- area:ui
+- v1
+
+## Assignees
+
+_No assignees_
+
+
+
+## Issue Body
+
+## Summary
+
+Implement the main catalog browsing page.
+
+The catalog page should provide a dedicated surface for browsing all movies and using basic title search.
+
+## Goal
+
+Allow users to browse the movie catalog outside of the home page.
+
+## Scope
+
+- Add a catalog route/page.
+- Fetch paginated movie summaries from the API.
+- Display movies using cards or a consistent catalog layout.
+- Integrate basic title search using the movie listing query parameter.
+- Support loading, empty, error, and no-result states.
+- Support explicit pagination.
+- Link each movie to the details page.
+- Keep the layout responsive.
+
+## Suggested Route
+
+```text
+/catalog
+```
+
+## Suggested API Usage
+
+```http
+GET /api/movies?query=central&page=1&pageSize=12
+```
+
+The response should use the shared paginated movie list shape:
+
+```json
+{
+  "items": [],
+  "page": 1,
+  "pageSize": 12,
+  "totalCount": 0,
+  "totalPages": 0,
+  "hasPreviousPage": false,
+  "hasNextPage": false
+}
+```
+
+Invalid pagination or query parameters should use the shared invalid request response:
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+```
+
+```json
+{
+  "type": "https://smartmoviecatalog.dev/problems/invalid-request",
+  "title": "Invalid request.",
+  "status": 400,
+  "detail": "The request could not be processed because it is malformed or contains invalid parameters.",
+  "instance": "/api/movies",
+  "errors": {
+    "page": [
+      "Page must be greater than or equal to 1."
+    ]
+  }
+}
+```
+
+## Suggested Initial UI
+
+- Page title: `Catalog`
+- Search input
+- Movie grid/list
+- Pagination controls
+- Empty state
+- Error state
+
+## Acceptance Criteria
+
+- Catalog page is reachable through app navigation.
+- Catalog page lists movies from the API.
+- Catalog page consumes the paginated movie list endpoint from issue #12.
+- Catalog page integrates title search from issue #16.
+- User can navigate from catalog item to movie details.
+- Catalog item navigation targets the movie details route backed by issue #13.
+- Catalog page handles loading state.
+- Catalog page handles empty catalog state.
+- Catalog page handles no search results state.
+- Catalog page handles API error state.
+- Pagination controls work consistently using `page`, `pageSize`, `totalCount`, `totalPages`, `hasPreviousPage`, and `hasNextPage`.
+- Layout is responsive.
+- Components use typed API services instead of direct `HttpClient`.
+- No unsupported future architecture terms are shown in the UI.
+
+## Technical Notes
+
+- Keep this page focused on basic browsing for V1.
+- Do not introduce advanced filter UI unless backend support exists.
+- Search integration should remain basic title search through `GET /api/movies?query=...`.
+- Reuse the movie card component from issue #17 if available.
+- Keep catalog state simple and maintainable.
+
+## Out of Scope
+
+- Genre filter.
+- Year filter.
+- AI analyzed filter.
+- Semantic search.
+- Vector search.
+- Recommendations.
+- Poster similarity.
+- RAG.
+- Authentication-specific catalog behavior.
+
+
+## Comments
+
+_No comments_
+
+## Instructions for Spec Kit
+
+Use this GitHub issue as the primary source of truth.
+
+Convert the issue into a Spec Kit feature specification before creating the implementation plan.
+
+Preserve:
+
+- business goal;
+- user stories;
+- acceptance criteria;
+- technical constraints;
+- non-goals;
+- dependencies;
+- open questions.
+
+If information is missing, add it under a clearly marked **Clarifications Needed** section instead of inventing requirements.
+
+If the issue conflicts with existing project documentation, explicitly call out the conflict.
+
+Prefer a small, incremental implementation plan aligned with the repository's existing architecture, folder structure, language, framework, and conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ Do not read, modify, or base analysis on generated/vendor output unless explicit
   - `test:`
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/011-create-movie/plan.md`.
+Current Spec Kit plan: `specs/018-catalog-page/plan.md`.
 
 Before using Spec Kit skills, read `.specify/memory/constitution.md`.
 If the spec, plan, or implementation touches backend, API, contracts, domain,

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -1,7 +1,7 @@
 # Frontend
 
 ## Current State
-The frontend is an Angular 21 SPA in `frontend`. The current first screen is the authentication login page.
+The frontend is an Angular 21 SPA in `frontend`. The root route renders the authentication login page, and `/catalog` renders the public movie catalog browsing page.
 
 Primary references:
 
@@ -9,6 +9,13 @@ Primary references:
 - `frontend/angular.json`
 - `frontend/src/app`
 - `frontend/DESIGN.md`
+
+## Routing
+- `/` displays the authentication login page.
+- `/catalog` displays the public V1 catalog page.
+- `/catalog` reads `query`, `page`, and `pageSize` from URL query parameters.
+- Catalog `pageSize` defaults to `12` when omitted or invalid. A valid URL `pageSize` is honored, but V1 does not show a page-size selector.
+- Catalog item links target the movie details route pattern `/movies/{id}` established by the movie details feature.
 
 ## Design System
 Before changing UI, read `frontend/DESIGN.md`.
@@ -28,6 +35,14 @@ Do not introduce another design system, component library, custom palette, or vi
 - Keep API access isolated from presentation logic as the application grows.
 - Prefer strongly typed models for API responses.
 - Do not introduce global mutable state unless there is a clear product need.
+
+## Movie Catalog UI
+- The catalog page lives under `frontend/src/app/catalog/catalog-page`.
+- Movie catalog HTTP calls are isolated in `frontend/src/app/movies/movies-api.ts`.
+- Movie catalog contracts are mirrored as TypeScript interfaces in `frontend/src/app/movies/movie.models.ts` and must stay aligned with the movie listing/search API contracts.
+- Catalog components must not call `HttpClient` directly.
+- The V1 catalog route is public and does not require route guards or an authenticated frontend session.
+- Search is basic title search through `GET /api/movies?query=...`; do not show semantic search, vector search, RAG, CLIP, recommendation, or AI ranking terminology for this feature.
 
 ## Authentication UI
 - The login screen lives under `frontend/src/app/auth/login-page`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6203,13 +6203,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
-      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -6772,9 +6772,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9747,16 +9747,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/socks/node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/source-map": {

--- a/frontend/src/app/app.css
+++ b/frontend/src/app/app.css
@@ -1,4 +1,69 @@
 :host {
   display: block;
   min-height: 100vh;
+  background: #09090b;
+  color: #fafafa;
+}
+
+.app-shell {
+  min-height: 100vh;
+  background: #09090b;
+}
+
+.top-nav {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 4.5rem;
+  padding: 0 1.5rem;
+  border-bottom: 1px solid rgb(255 255 255 / 0.1);
+  background: rgb(9 9 11 / 0.82);
+  backdrop-filter: blur(1rem);
+}
+
+.brand-link {
+  max-width: min(70vw, 24rem);
+  overflow: hidden;
+  color: transparent;
+  background: linear-gradient(90deg, #818cf8, #c084fc);
+  background-clip: text;
+  font-family: 'Plus Jakarta Sans', Inter, Arial, sans-serif;
+  font-size: 1rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+nav a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.75rem;
+  border-bottom: 2px solid transparent;
+  color: #a1a1aa;
+  font-size: 0.9rem;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+nav a:hover,
+nav a.active-link {
+  border-bottom-color: #8b5cf6;
+  color: #fafafa;
+}
+
+.app-main {
+  min-height: 100vh;
 }

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -1,1 +1,12 @@
-<app-login-page />
+<div class="app-shell">
+  <header class="top-nav">
+    <a class="brand-link" routerLink="/">Smart Movie Catalog</a>
+    <nav aria-label="Primary navigation">
+      <a routerLink="/catalog" routerLinkActive="active-link">Catalog</a>
+    </nav>
+  </header>
+
+  <main class="app-main">
+    <router-outlet />
+  </main>
+</div>

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -1,30 +1,73 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter, Router } from '@angular/router';
+import { of } from 'rxjs';
 import { App } from './app';
+import { LoginPage } from './auth/login-page/login-page';
+import { CatalogPage } from './catalog/catalog-page/catalog-page';
+import { PagedMovieSummaryResponse } from './movies/movie.models';
+import { MoviesApi } from './movies/movies-api';
 
 describe('App', () => {
   let component: App;
   let fixture: ComponentFixture<App>;
+  let router: Router;
+
+  const emptyResponse: PagedMovieSummaryResponse = {
+    items: [],
+    page: 1,
+    pageSize: 12,
+    totalCount: 0,
+    totalPages: 0,
+    hasPreviousPage: false,
+    hasNextPage: false
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App]
+      imports: [App],
+      providers: [
+        provideRouter([
+          { path: '', component: LoginPage },
+          { path: 'catalog', component: CatalogPage }
+        ]),
+        {
+          provide: MoviesApi,
+          useValue: {
+            listMovies: vi.fn(() => of(emptyResponse))
+          }
+        }
+      ]
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(App);
     component = fixture.componentInstance;
+    router = TestBed.inject(Router);
   });
 
   it('should create the app', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render the app brand', () => {
+  it('should render the app brand and catalog navigation link', () => {
     fixture.detectChanges();
 
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Smart Movie Catalog');
-    expect(compiled.querySelector('app-login-page')).toBeTruthy();
+    expect(compiled.querySelector('.brand-link')?.textContent).toContain('Smart Movie Catalog');
+    expect(compiled.querySelector('a[routerLink="/catalog"]')?.textContent).toContain('Catalog');
+  });
+
+  it('should render the public catalog route without an auth guard', async () => {
+    fixture.detectChanges();
+
+    await router.navigateByUrl('/catalog');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('app-catalog-page')).toBeTruthy();
+    expect(compiled.textContent).toContain('Catalog');
   });
 });

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,10 +1,10 @@
 import { Component } from '@angular/core';
-import { LoginPage } from './auth/login-page/login-page';
+import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.html',
-  imports: [LoginPage],
+  imports: [RouterLink, RouterLinkActive, RouterOutlet],
   styleUrl: './app.css'
 })
 export class App {

--- a/frontend/src/app/catalog/catalog-page/catalog-page.css
+++ b/frontend/src/app/catalog/catalog-page/catalog-page.css
@@ -1,0 +1,295 @@
+:host {
+  display: block;
+}
+
+.catalog-page {
+  width: min(100%, 80rem);
+  margin: 0 auto;
+  padding: 6rem 1.5rem 3rem;
+  color: #fafafa;
+}
+
+.catalog-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 28rem);
+  gap: 1.5rem;
+  align-items: end;
+  margin-bottom: 2rem;
+}
+
+.catalog-kicker {
+  margin: 0 0 0.5rem;
+  color: #a1a1aa;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0;
+  font-family: 'Plus Jakarta Sans', Inter, Arial, sans-serif;
+  font-size: clamp(2.35rem, 6vw, 4rem);
+  font-weight: 800;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.search-form {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.search-label {
+  color: #a1a1aa;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.search-shell {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 3.25rem;
+  border: 1px solid #27272a;
+  border-radius: 999px;
+  background: #18181b;
+  color: #a1a1aa;
+  overflow: hidden;
+}
+
+.search-shell:focus-within {
+  border-color: #8b5cf6;
+  box-shadow: 0 0 0 0.2rem rgb(139 92 246 / 0.22);
+}
+
+.search-shell > .material-symbols-outlined {
+  margin-left: 1rem;
+}
+
+input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  padding: 0.85rem 1rem;
+  background: transparent;
+  color: #fafafa;
+}
+
+input::placeholder {
+  color: #71717a;
+}
+
+button {
+  border: 0;
+  border-radius: 0.5rem;
+  color: #fafafa;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.search-shell button {
+  min-height: 2.75rem;
+  margin-right: 0.25rem;
+  padding: 0 1rem;
+  background: linear-gradient(90deg, #6366f1, #9333ea);
+}
+
+.catalog-state {
+  display: grid;
+  place-items: center;
+  min-height: 20rem;
+  gap: 0.75rem;
+  border: 1px solid #27272a;
+  border-radius: 0.75rem;
+  background: #18181b;
+  text-align: center;
+  color: #d4d4d8;
+}
+
+.catalog-state .material-symbols-outlined {
+  display: grid;
+  place-items: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  background: rgb(139 92 246 / 0.12);
+  color: #8b5cf6;
+}
+
+.catalog-state h2 {
+  margin-bottom: 0;
+  font-family: 'Plus Jakarta Sans', Inter, Arial, sans-serif;
+  font-size: 1.5rem;
+  letter-spacing: 0;
+  color: #fafafa;
+}
+
+.catalog-state p {
+  margin-bottom: 0;
+}
+
+.catalog-state-error .material-symbols-outlined {
+  background: rgb(220 38 38 / 0.12);
+  color: #fca5a5;
+}
+
+.catalog-toolbar {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  color: #a1a1aa;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.catalog-toolbar p {
+  margin-bottom: 0;
+}
+
+.movie-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+  gap: 1rem;
+}
+
+.movie-card {
+  position: relative;
+  min-height: 21rem;
+  overflow: hidden;
+  border: 1px solid #27272a;
+  border-radius: 0.75rem;
+  background: #18181b;
+  color: #fafafa;
+  text-decoration: none;
+  transition: border-color 160ms ease, transform 160ms ease;
+}
+
+.movie-card:hover,
+.movie-card:focus-visible {
+  border-color: rgb(139 92 246 / 0.7);
+  transform: translateY(-0.15rem);
+  outline: 0;
+}
+
+.poster-frame {
+  position: absolute;
+  inset: 0;
+}
+
+.poster-frame::after {
+  position: absolute;
+  inset: 0;
+  content: '';
+  background: linear-gradient(to top, rgb(0 0 0 / 0.92), rgb(0 0 0 / 0.38), transparent);
+}
+
+.poster-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.poster-placeholder {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(145deg, #27272a, #09090b);
+  color: #71717a;
+}
+
+.poster-placeholder .material-symbols-outlined {
+  font-size: 3rem;
+}
+
+.movie-card-content {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 1;
+  padding: 1rem;
+}
+
+.movie-card-content h2 {
+  margin-bottom: 0.55rem;
+  font-family: 'Plus Jakarta Sans', Inter, Arial, sans-serif;
+  font-size: 1.1rem;
+  line-height: 1.2;
+  letter-spacing: 0;
+}
+
+.movie-meta,
+.movie-genres,
+.movie-director {
+  margin-bottom: 0.4rem;
+  color: #d4d4d8;
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.movie-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: #a1a1aa;
+  font-weight: 700;
+}
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  color: #a1a1aa;
+  font-weight: 700;
+}
+
+.pagination button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-height: 2.75rem;
+  padding: 0 1rem;
+  border: 1px solid #3f3f46;
+  background: #27272a;
+}
+
+.pagination button:not(:disabled):hover {
+  background: #3f3f46;
+}
+
+.pagination button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+@media (max-width: 48rem) {
+  .catalog-page {
+    padding-inline: 1rem;
+  }
+
+  .catalog-header {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog-toolbar,
+  .pagination {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .pagination button {
+    justify-content: center;
+  }
+}

--- a/frontend/src/app/catalog/catalog-page/catalog-page.html
+++ b/frontend/src/app/catalog/catalog-page/catalog-page.html
@@ -1,0 +1,91 @@
+<section class="catalog-page" aria-labelledby="catalog-title">
+  <header class="catalog-header">
+    <div>
+      <p class="catalog-kicker">Movie Catalog</p>
+      <h1 id="catalog-title">Catalog</h1>
+    </div>
+
+    <form class="search-form" (ngSubmit)="submitSearch()" role="search">
+      <label class="search-label" for="movie-search">Title search</label>
+      <div class="search-shell">
+        <span class="material-symbols-outlined" aria-hidden="true">search</span>
+        <input
+          id="movie-search"
+          type="search"
+          autocomplete="off"
+          placeholder="Search by title"
+          [formControl]="searchControl">
+        <button type="submit">Search</button>
+      </div>
+    </form>
+  </header>
+
+  <div class="catalog-state" *ngIf="loadState() === 'loading'" role="status">
+    <span class="material-symbols-outlined" aria-hidden="true">hourglass_top</span>
+    <p>Loading catalog</p>
+  </div>
+
+  <div class="catalog-state" *ngIf="loadState() === 'emptyCatalog'">
+    <span class="material-symbols-outlined" aria-hidden="true">movie</span>
+    <h2>No movies yet</h2>
+    <p>The catalog is ready for the first movie.</p>
+  </div>
+
+  <div class="catalog-state" *ngIf="loadState() === 'noResults'">
+    <span class="material-symbols-outlined" aria-hidden="true">search_off</span>
+    <h2>No results</h2>
+    <p>No movies match this title search.</p>
+  </div>
+
+  <div class="catalog-state catalog-state-error" *ngIf="loadState() === 'error'" role="alert">
+    <span class="material-symbols-outlined" aria-hidden="true">error</span>
+    <h2>Catalog unavailable</h2>
+    <p>Try again in a moment.</p>
+  </div>
+
+  <ng-container *ngIf="loadState() === 'success' && response() as page">
+    <div class="catalog-toolbar">
+      <p>{{ resultSummary() }}</p>
+      <p>Page {{ page.page }} of {{ page.totalPages }}</p>
+    </div>
+
+    <div class="movie-grid">
+      <a
+        class="movie-card"
+        *ngFor="let movie of movies(); trackBy: trackByMovieId"
+        [routerLink]="detailsLink(movie)"
+        [attr.aria-label]="'Open details for ' + movie.title">
+        <div class="poster-frame">
+          <img *ngIf="movie.posterUrl; else posterPlaceholder" [src]="movie.posterUrl" [alt]="movie.title + ' poster'">
+          <ng-template #posterPlaceholder>
+            <div class="poster-placeholder" aria-hidden="true">
+              <span class="material-symbols-outlined">movie</span>
+            </div>
+          </ng-template>
+        </div>
+
+        <div class="movie-card-content">
+          <h2>{{ movie.title }}</h2>
+          <p class="movie-meta">
+            <span>{{ movie.releaseYear }}</span>
+            <span>{{ movie.countryCode }}</span>
+          </p>
+          <p class="movie-director" *ngIf="movie.director">{{ movie.director }}</p>
+          <p class="movie-genres" *ngIf="movie.genres.length > 0">{{ movie.genres.join(' / ') }}</p>
+        </div>
+      </a>
+    </div>
+
+    <nav class="pagination" aria-label="Catalog pagination">
+      <button type="button" (click)="previousPage()" [disabled]="!page.hasPreviousPage">
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_left</span>
+        <span>Previous</span>
+      </button>
+      <span>Page {{ page.page }} of {{ page.totalPages }}</span>
+      <button type="button" (click)="nextPage()" [disabled]="!page.hasNextPage">
+        <span>Next</span>
+        <span class="material-symbols-outlined" aria-hidden="true">chevron_right</span>
+      </button>
+    </nav>
+  </ng-container>
+</section>

--- a/frontend/src/app/catalog/catalog-page/catalog-page.spec.ts
+++ b/frontend/src/app/catalog/catalog-page/catalog-page.spec.ts
@@ -1,0 +1,239 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ActivatedRoute, convertToParamMap, ParamMap, Router, provideRouter } from '@angular/router';
+import { BehaviorSubject, NEVER, of, throwError } from 'rxjs';
+import { MovieListQuery, PagedMovieSummaryResponse } from '../../movies/movie.models';
+import { MoviesApi } from '../../movies/movies-api';
+import { CatalogPage } from './catalog-page';
+
+describe('CatalogPage', () => {
+  let fixture: ComponentFixture<CatalogPage>;
+  let queryParamMap: BehaviorSubject<ParamMap>;
+  let moviesApi: {
+    listMovies: ReturnType<typeof vi.fn<(query: MovieListQuery) => ReturnType<MoviesApi['listMovies']>>>;
+  };
+  let router: Router;
+
+  const movieResponse: PagedMovieSummaryResponse = {
+    items: [
+      {
+        id: 'movie-1',
+        title: 'Central do Brasil',
+        releaseYear: 1998,
+        countryCode: 'BR',
+        genres: ['Drama'],
+        director: 'Walter Salles',
+        posterUrl: null,
+        createdAt: '2026-05-02T00:00:00Z'
+      }
+    ],
+    page: 2,
+    pageSize: 12,
+    totalCount: 47,
+    totalPages: 4,
+    hasPreviousPage: true,
+    hasNextPage: true
+  };
+
+  const emptyResponse: PagedMovieSummaryResponse = {
+    items: [],
+    page: 1,
+    pageSize: 12,
+    totalCount: 0,
+    totalPages: 0,
+    hasPreviousPage: false,
+    hasNextPage: false
+  };
+
+  beforeEach(async () => {
+    queryParamMap = new BehaviorSubject<ParamMap>(convertToParamMap({}));
+    moviesApi = {
+      listMovies: vi.fn(() => of(movieResponse))
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [CatalogPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            queryParamMap: queryParamMap.asObservable()
+          }
+        },
+        { provide: MoviesApi, useValue: moviesApi }
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    vi.spyOn(router, 'navigate').mockResolvedValue(true);
+  });
+
+  function createComponent(): void {
+    fixture = TestBed.createComponent(CatalogPage);
+    fixture.detectChanges();
+  }
+
+  it('should render the initial catalog page shell', () => {
+    moviesApi.listMovies.mockReturnValue(NEVER);
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('h1')?.textContent).toContain('Catalog');
+    expect(compiled.querySelector('#movie-search')).toBeTruthy();
+    expect(compiled.textContent).toContain('Loading catalog');
+  });
+
+  it('should request and render movie summaries from MoviesApi', () => {
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(moviesApi.listMovies).toHaveBeenCalledWith({ page: 1, pageSize: 12, query: undefined });
+    expect(compiled.textContent).toContain('Central do Brasil');
+    expect(compiled.textContent).toContain('Walter Salles');
+  });
+
+  it('should use MoviesApi as the catalog API boundary', () => {
+    createComponent();
+
+    expect(moviesApi.listMovies).toHaveBeenCalledTimes(1);
+  });
+
+  it('should read query, page, and pageSize from URL query parameters', () => {
+    queryParamMap.next(convertToParamMap({
+      query: 'central',
+      page: '2',
+      pageSize: '24'
+    }));
+    createComponent();
+
+    const input = fixture.nativeElement.querySelector('#movie-search') as HTMLInputElement;
+    expect(input.value).toBe('central');
+    expect(moviesApi.listMovies).toHaveBeenCalledWith({
+      query: 'central',
+      page: 2,
+      pageSize: 24
+    });
+  });
+
+  it('should update URL query parameters and reset page when searching', () => {
+    queryParamMap.next(convertToParamMap({
+      query: 'central',
+      page: '2',
+      pageSize: '12'
+    }));
+    createComponent();
+
+    const input = fixture.nativeElement.querySelector('#movie-search') as HTMLInputElement;
+    input.value = 'matrix';
+    input.dispatchEvent(new Event('input'));
+
+    fixture.debugElement.query(By.css('form')).triggerEventHandler('ngSubmit');
+
+    expect(router.navigate).toHaveBeenCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: {
+        query: 'matrix',
+        page: 1,
+        pageSize: 12
+      },
+      queryParamsHandling: 'merge'
+    });
+  });
+
+  it('should omit blank search query from URL state', () => {
+    createComponent();
+
+    const input = fixture.nativeElement.querySelector('#movie-search') as HTMLInputElement;
+    input.value = '   ';
+    input.dispatchEvent(new Event('input'));
+
+    fixture.debugElement.query(By.css('form')).triggerEventHandler('ngSubmit');
+
+    expect(router.navigate).toHaveBeenCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: {
+        query: null,
+        page: 1,
+        pageSize: 12
+      },
+      queryParamsHandling: 'merge'
+    });
+  });
+
+  it('should render empty catalog state for an empty default list', () => {
+    moviesApi.listMovies.mockReturnValue(of(emptyResponse));
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('No movies yet');
+  });
+
+  it('should render no-result state for an empty title search', () => {
+    queryParamMap.next(convertToParamMap({ query: 'missing' }));
+    moviesApi.listMovies.mockReturnValue(of(emptyResponse));
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('No results');
+  });
+
+  it('should render generic API error state', () => {
+    moviesApi.listMovies.mockReturnValue(throwError(() => new Error('failed')));
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Catalog unavailable');
+    expect(compiled.textContent).toContain('Try again in a moment.');
+  });
+
+  it('should update URL state through pagination controls', () => {
+    queryParamMap.next(convertToParamMap({
+      query: 'central',
+      page: '2',
+      pageSize: '12'
+    }));
+    createComponent();
+
+    const buttons = fixture.nativeElement.querySelectorAll('.pagination button') as NodeListOf<HTMLButtonElement>;
+    buttons[1]?.click();
+
+    expect(router.navigate).toHaveBeenCalledWith([], {
+      relativeTo: expect.anything(),
+      queryParams: {
+        query: 'central',
+        page: 3,
+        pageSize: 12
+      },
+      queryParamsHandling: 'merge'
+    });
+  });
+
+  it('should normalize invalid URL page and pageSize before API calls', () => {
+    queryParamMap.next(convertToParamMap({
+      page: 'zero',
+      pageSize: '-2'
+    }));
+    createComponent();
+
+    expect(moviesApi.listMovies).toHaveBeenCalledWith({
+      query: undefined,
+      page: 1,
+      pageSize: 12
+    });
+  });
+
+  it('should not render a page-size selector', () => {
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('select')).toBeNull();
+  });
+
+  it('should link catalog items to movie details', () => {
+    createComponent();
+
+    const link = fixture.nativeElement.querySelector('.movie-card') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/movies/movie-1');
+  });
+});

--- a/frontend/src/app/catalog/catalog-page/catalog-page.ts
+++ b/frontend/src/app/catalog/catalog-page/catalog-page.ts
@@ -1,0 +1,173 @@
+import { CommonModule } from '@angular/common';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute, ParamMap, Router, RouterLink } from '@angular/router';
+import { catchError, distinctUntilChanged, map, of, switchMap, tap } from 'rxjs';
+import {
+  CatalogLoadState,
+  CatalogViewState,
+  MovieListQuery,
+  MovieSummary,
+  PagedMovieSummaryResponse
+} from '../../movies/movie.models';
+import { MoviesApi } from '../../movies/movies-api';
+
+interface CatalogLoadResult {
+  state: CatalogViewState;
+  response: PagedMovieSummaryResponse | null;
+  failed: boolean;
+}
+
+@Component({
+  selector: 'app-catalog-page',
+  imports: [CommonModule, ReactiveFormsModule, RouterLink],
+  templateUrl: './catalog-page.html',
+  styleUrl: './catalog-page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class CatalogPage implements OnInit {
+  private readonly moviesApi = inject(MoviesApi);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly searchControl = new FormControl('', { nonNullable: true });
+  protected readonly viewState = signal<CatalogViewState>({
+    query: '',
+    page: 1,
+    pageSize: 12
+  });
+  protected readonly loadState = signal<CatalogLoadState>('loading');
+  protected readonly response = signal<PagedMovieSummaryResponse | null>(null);
+
+  protected readonly movies = computed(() => this.response()?.items ?? []);
+  protected readonly resultSummary = computed(() => {
+    const currentResponse = this.response();
+    if (!currentResponse) {
+      return '';
+    }
+
+    const label = currentResponse.totalCount === 1 ? 'movie' : 'movies';
+    return `${currentResponse.totalCount} ${label}`;
+  });
+
+  public ngOnInit(): void {
+    this.route.queryParamMap.pipe(
+      map(params => this.toCatalogViewState(params)),
+      distinctUntilChanged((left, right) => this.sameViewState(left, right)),
+      tap(state => this.prepareForLoad(state)),
+      switchMap(state => this.moviesApi.listMovies(this.toMovieListQuery(state)).pipe(
+        map(response => ({ state, response, failed: false })),
+        catchError(() => of({ state, response: null, failed: true }))
+      )),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(result => this.applyLoadResult(result));
+  }
+
+  protected submitSearch(): void {
+    const query = this.searchControl.value.trim();
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: {
+        query: query || null,
+        page: 1,
+        pageSize: this.viewState().pageSize
+      },
+      queryParamsHandling: 'merge'
+    });
+  }
+
+  protected previousPage(): void {
+    const currentResponse = this.response();
+    if (!currentResponse?.hasPreviousPage) {
+      return;
+    }
+
+    this.navigateToPage(this.viewState().page - 1);
+  }
+
+  protected nextPage(): void {
+    const currentResponse = this.response();
+    if (!currentResponse?.hasNextPage) {
+      return;
+    }
+
+    this.navigateToPage(this.viewState().page + 1);
+  }
+
+  protected detailsLink(movie: MovieSummary): string[] {
+    return ['/movies', movie.id];
+  }
+
+  protected trackByMovieId(_index: number, movie: MovieSummary): string {
+    return movie.id;
+  }
+
+  private navigateToPage(page: number): void {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: {
+        page,
+        pageSize: this.viewState().pageSize,
+        query: this.viewState().query || null
+      },
+      queryParamsHandling: 'merge'
+    });
+  }
+
+  private prepareForLoad(state: CatalogViewState): void {
+    this.viewState.set(state);
+    this.searchControl.setValue(state.query, { emitEvent: false });
+    this.loadState.set('loading');
+    this.response.set(null);
+  }
+
+  private applyLoadResult(result: CatalogLoadResult): void {
+    if (result.failed || !result.response) {
+      this.loadState.set('error');
+      this.response.set(null);
+      return;
+    }
+
+    this.response.set(result.response);
+
+    if (result.response.items.length > 0) {
+      this.loadState.set('success');
+      return;
+    }
+
+    this.loadState.set(result.state.query ? 'noResults' : 'emptyCatalog');
+  }
+
+  private toMovieListQuery(state: CatalogViewState): MovieListQuery {
+    return {
+      query: state.query || undefined,
+      page: state.page,
+      pageSize: state.pageSize
+    };
+  }
+
+  private toCatalogViewState(params: ParamMap): CatalogViewState {
+    return {
+      query: params.get('query')?.trim() ?? '',
+      page: this.parsePositiveInteger(params.get('page'), 1),
+      pageSize: this.parsePositiveInteger(params.get('pageSize'), 12)
+    };
+  }
+
+  private parsePositiveInteger(value: string | null, fallback: number): number {
+    if (!value) {
+      return fallback;
+    }
+
+    const parsed = Number(value);
+    return Number.isInteger(parsed) && parsed >= 1 ? parsed : fallback;
+  }
+
+  private sameViewState(left: CatalogViewState, right: CatalogViewState): boolean {
+    return left.query === right.query &&
+      left.page === right.page &&
+      left.pageSize === right.pageSize;
+  }
+}

--- a/frontend/src/app/movies/movie.models.ts
+++ b/frontend/src/app/movies/movie.models.ts
@@ -1,0 +1,34 @@
+export interface MovieSummary {
+  id: string;
+  title: string;
+  releaseYear: number;
+  countryCode: string;
+  genres: string[];
+  director: string | null;
+  posterUrl: string | null;
+  createdAt: string;
+}
+
+export interface PagedMovieSummaryResponse {
+  items: MovieSummary[];
+  page: number;
+  pageSize: number;
+  totalCount: number;
+  totalPages: number;
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+}
+
+export interface MovieListQuery {
+  query?: string;
+  page: number;
+  pageSize: number;
+}
+
+export interface CatalogViewState {
+  query: string;
+  page: number;
+  pageSize: number;
+}
+
+export type CatalogLoadState = 'loading' | 'success' | 'emptyCatalog' | 'noResults' | 'error';

--- a/frontend/src/app/movies/movies-api.spec.ts
+++ b/frontend/src/app/movies/movies-api.spec.ts
@@ -1,0 +1,105 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { PagedMovieSummaryResponse } from './movie.models';
+import { MoviesApi } from './movies-api';
+
+describe('MoviesApi', () => {
+  let moviesApi: MoviesApi;
+  let httpTestingController: HttpTestingController;
+
+  const response: PagedMovieSummaryResponse = {
+    items: [
+      {
+        id: 'movie-1',
+        title: 'Central do Brasil',
+        releaseYear: 1998,
+        countryCode: 'BR',
+        genres: ['Drama'],
+        director: 'Walter Salles',
+        posterUrl: null,
+        createdAt: '2026-05-02T00:00:00Z'
+      }
+    ],
+    page: 2,
+    pageSize: 12,
+    totalCount: 47,
+    totalPages: 4,
+    hasPreviousPage: true,
+    hasNextPage: true
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        MoviesApi,
+        provideHttpClient(),
+        provideHttpClientTesting()
+      ]
+    });
+
+    moviesApi = TestBed.inject(MoviesApi);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+  });
+
+  it('should request movies with page, pageSize, and title query parameters', () => {
+    moviesApi.listMovies({ query: 'central', page: 2, pageSize: 12 }).subscribe(result => {
+      expect(result).toEqual(response);
+    });
+
+    const request = httpTestingController.expectOne(request =>
+      request.url === '/api/movies' &&
+      request.params.get('query') === 'central' &&
+      request.params.get('page') === '2' &&
+      request.params.get('pageSize') === '12'
+    );
+
+    expect(request.request.method).toBe('GET');
+    request.flush(response);
+  });
+
+  it('should omit blank title query parameters', () => {
+    moviesApi.listMovies({ query: '   ', page: 1, pageSize: 12 }).subscribe();
+
+    const request = httpTestingController.expectOne(request =>
+      request.url === '/api/movies' &&
+      !request.params.has('query') &&
+      request.params.get('page') === '1' &&
+      request.params.get('pageSize') === '12'
+    );
+
+    request.flush({
+      ...response,
+      items: [],
+      page: 1,
+      totalCount: 0,
+      totalPages: 0,
+      hasPreviousPage: false,
+      hasNextPage: false
+    });
+  });
+
+  it('should map the paginated movie summary response shape', () => {
+    moviesApi.listMovies({ page: 2, pageSize: 12 }).subscribe(result => {
+      expect(result.items[0]?.title).toBe('Central do Brasil');
+      expect(result.page).toBe(2);
+      expect(result.pageSize).toBe(12);
+      expect(result.totalCount).toBe(47);
+      expect(result.totalPages).toBe(4);
+      expect(result.hasPreviousPage).toBe(true);
+      expect(result.hasNextPage).toBe(true);
+    });
+
+    const request = httpTestingController.expectOne(request =>
+      request.url === '/api/movies' &&
+      request.params.get('page') === '2' &&
+      request.params.get('pageSize') === '12'
+    );
+
+    request.flush(response);
+  });
+});

--- a/frontend/src/app/movies/movies-api.ts
+++ b/frontend/src/app/movies/movies-api.ts
@@ -1,0 +1,24 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { MovieListQuery, PagedMovieSummaryResponse } from './movie.models';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class MoviesApi {
+  private readonly http = inject(HttpClient);
+
+  public listMovies(query: MovieListQuery): Observable<PagedMovieSummaryResponse> {
+    let params = new HttpParams()
+      .set('page', query.page.toString())
+      .set('pageSize', query.pageSize.toString());
+
+    const titleQuery = query.query?.trim();
+    if (titleQuery) {
+      params = params.set('query', titleQuery);
+    }
+
+    return this.http.get<PagedMovieSummaryResponse>('/api/movies', { params });
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,12 +3,17 @@ import { provideHttpClient } from '@angular/common/http';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
 import { App } from './app/app';
+import { LoginPage } from './app/auth/login-page/login-page';
+import { CatalogPage } from './app/catalog/catalog-page/catalog-page';
 
 bootstrapApplication(App, {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideHttpClient(),
-    provideRouter([]),
+    provideRouter([
+      { path: '', component: LoginPage },
+      { path: 'catalog', component: CatalogPage }
+    ]),
   ]
 })
   .catch(err => console.error(err));

--- a/specs/018-catalog-page/.spec-context.json
+++ b/specs/018-catalog-page/.spec-context.json
@@ -1,0 +1,80 @@
+{
+  "workflow": "speckit",
+  "specName": "018-catalog-page",
+  "branch": "018-catalog-page",
+  "selectedAt": "2026-05-06T23:18:50.585Z",
+  "currentStep": "tasks",
+  "status": "tasking",
+  "stepHistory": {
+    "plan": {
+      "startedAt": "2026-05-06T23:18:54.968Z",
+      "completedAt": "2026-05-06T23:19:28.941Z"
+    },
+    "tasks": {
+      "startedAt": "2026-05-06T23:19:28.944Z",
+      "completedAt": null
+    }
+  },
+  "transitions": [
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-06T23:18:54.968Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-06T23:18:54.970Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-06T23:18:57.186Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-06T23:18:57.188Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-06T23:19:28.941Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-06T23:19:28.944Z"
+    }
+  ]
+}

--- a/specs/018-catalog-page/contracts/catalog-ui.md
+++ b/specs/018-catalog-page/contracts/catalog-ui.md
@@ -1,0 +1,95 @@
+# Contract: Catalog Page UI And API Consumption
+
+## Route Contract
+
+```text
+GET /catalog
+GET /catalog?query={query}&page={page}&pageSize={pageSize}
+```
+
+Rules:
+
+- `/catalog` is publicly reachable for V1.
+- No frontend authentication guard is required for this route.
+- `query` is optional and represents basic title search.
+- `page` is optional, defaults to `1`, and must be normalized to a positive integer before API calls.
+- `pageSize` is optional, defaults to `12`, and must be normalized to a positive integer before API calls.
+- The UI must not expose a page-size selector in V1.
+
+## Frontend API Service Contract
+
+`MoviesApi` exposes movie listing through a typed method equivalent to:
+
+```ts
+listMovies(query: MovieListQuery): Observable<PagedMovieSummaryResponse>
+```
+
+Request mapping:
+
+```http
+GET /api/movies?page=1&pageSize=12
+GET /api/movies?query=central&page=1&pageSize=12
+```
+
+Rules:
+
+- Components must call `MoviesApi`, not `HttpClient` directly.
+- Blank search query is omitted from the API request.
+- URL query parameters are normalized before creating the API request.
+
+## Expected API Response
+
+```json
+{
+  "items": [
+    {
+      "id": "movie-id",
+      "title": "Central do Brasil",
+      "releaseYear": 1998,
+      "countryCode": "BR",
+      "genres": ["Drama"],
+      "director": "Walter Salles",
+      "posterUrl": null,
+      "createdAt": "2026-05-02T00:00:00Z"
+    }
+  ],
+  "page": 1,
+  "pageSize": 12,
+  "totalCount": 47,
+  "totalPages": 4,
+  "hasPreviousPage": false,
+  "hasNextPage": true
+}
+```
+
+## Error Contract
+
+Invalid API query or pagination parameters from the backend use `application/problem+json`:
+
+```json
+{
+  "type": "https://smartmoviecatalog.dev/problems/invalid-request",
+  "title": "Invalid request.",
+  "status": 400,
+  "detail": "The request could not be processed because it is malformed or contains invalid parameters.",
+  "instance": "/api/movies",
+  "errors": {
+    "page": ["Page must be greater than or equal to 1."]
+  }
+}
+```
+
+UI rule:
+
+- Display a generic catalog error state.
+- Do not expose internal backend exception details.
+
+## Navigation Contract
+
+Catalog item links target the movie details route from issue #13:
+
+```text
+/movies/{id}
+```
+
+If issue #13 establishes a different route before implementation, update this contract and the catalog tests to match.

--- a/specs/018-catalog-page/data-model.md
+++ b/specs/018-catalog-page/data-model.md
@@ -1,0 +1,71 @@
+# Data Model: Catalog Page
+
+This feature adds frontend TypeScript models and UI state only. It does not add backend domain or persistence entities.
+
+## MovieSummary
+
+**Purpose**: Lightweight movie item rendered in the catalog grid/list.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | string | Yes | Used for details route generation |
+| `title` | string | Yes | Primary card title |
+| `releaseYear` | number | Yes | Display metadata |
+| `countryCode` | string | Yes | Display metadata when useful |
+| `genres` | string[] | Yes | May be empty |
+| `director` | string or null | No | Display when present |
+| `posterUrl` | string or null | No | Use placeholder when absent |
+| `createdAt` | string | Yes | ISO-like API timestamp from issue #12 |
+
+## PagedMovieSummaryResponse
+
+**Purpose**: API response consumed by the catalog page.
+
+| Field | Type | Required | Validation / Use |
+|-------|------|----------|------------------|
+| `items` | `MovieSummary[]` | Yes | Rendered as catalog results |
+| `page` | number | Yes | Current API page |
+| `pageSize` | number | Yes | Current API page size |
+| `totalCount` | number | Yes | Used for result summary |
+| `totalPages` | number | Yes | Used for pagination display |
+| `hasPreviousPage` | boolean | Yes | Enables previous control |
+| `hasNextPage` | boolean | Yes | Enables next control |
+
+## MovieListQuery
+
+**Purpose**: Normalized request state passed to `MoviesApi`.
+
+| Field | Type | Required | Validation / Normalization |
+|-------|------|----------|----------------------------|
+| `query` | string or undefined | No | Trim; omit when blank |
+| `page` | number | Yes | Positive integer; default `1` |
+| `pageSize` | number | Yes | Positive integer; default `12` |
+
+## CatalogViewState
+
+**Purpose**: UI state represented by URL query parameters and component state.
+
+| Field | Type | Required | Source |
+|-------|------|----------|--------|
+| `query` | string | Yes | URL query parameter `query`; defaults to empty string |
+| `page` | number | Yes | URL query parameter `page`; defaults to `1` |
+| `pageSize` | number | Yes | URL query parameter `pageSize`; defaults to `12` |
+
+## CatalogLoadState
+
+**Purpose**: User-observable state for the catalog page.
+
+Allowed states:
+
+- `loading`
+- `success`
+- `emptyCatalog`
+- `noResults`
+- `error`
+
+State rules:
+
+- `emptyCatalog`: empty query and `totalCount` is `0`.
+- `noResults`: non-empty query and no returned items.
+- `error`: API request fails or cannot be processed.
+- `success`: one or more movies are available for rendering.

--- a/specs/018-catalog-page/plan.md
+++ b/specs/018-catalog-page/plan.md
@@ -1,0 +1,237 @@
+# Implementation Plan: Catalog Page
+
+**Feature Directory**: `specs/018-catalog-page` | **Date**: 2026-05-06 | **Spec**: `specs/018-catalog-page/spec.md`
+**Input**: Feature specification from `specs/018-catalog-page/spec.md`
+
+## Summary
+
+Implement a public V1 Angular catalog page at `/catalog` that uses a typed `MoviesApi` service to load paginated movie summaries from `GET /api/movies`, supports basic title search, synchronizes `query`, `page`, and `pageSize` through URL query parameters, renders catalog states and pagination, and links each movie to the details route from issue #13.
+
+This plan is frontend-owned for issue #18. Backend list/search/details endpoints remain prerequisite work from issues #12, #16, and #13 unless scope is explicitly expanded.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.9 with Angular 21; backend context is ASP.NET Core 10 / C# but no backend implementation is owned here.
+**Primary Dependencies**: Angular core/common/forms/router, Angular `HttpClient`, RxJS 7.8, local CSS aligned with `frontend/DESIGN.md`.
+**Storage**: N/A for this feature; catalog state is represented by browser URL query parameters.
+**Testing**: Angular unit tests through `npm test -- --watch=false` using Vitest and Angular HTTP/component testing utilities.
+**Target Platform**: Browser SPA served through Angular dev server locally and ASP.NET Core SpaProxy/static fallback in integrated runtime.
+**Project Type**: Web application frontend feature in the existing monorepo.
+**Performance Goals**: Avoid duplicate API requests for the same state transition; render one page of movie summaries with default `pageSize=12`.
+**Constraints**: No new frontend dependencies, no new UI library, no new design system, no direct `HttpClient` use in components, no authentication requirement for `/catalog` in V1.
+**Scale/Scope**: One catalog route, one typed movie API service, URL-backed list/search/pagination state, and focused frontend tests.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- Actual architecture is the source of truth: pass. Current source has Angular 21 with `provideRouter([])`, typed auth API service patterns, and no catalog route yet.
+- Boundaries explicit: pass. Issue #18 implementation stays under `frontend`; backend API work is a prerequisite, not hidden in this feature.
+- Contracts drive cross-boundary work: pass with dependency. `GET /api/movies` response shape and details route must match issues #12/#16/#13 before implementation is complete.
+- Security and secret hygiene: pass. No secrets, bearer-token persistence, auth guards, provider details, or sensitive backend internals are introduced.
+- Small verified changes: pass. Work decomposes into route/app shell, typed API models/service, catalog UI state, tests, and documentation only if structure changes.
+- Frontend design compliance: pass. UI uses `frontend/DESIGN.md`, local CSS, dark cinematic direction, Material Symbols, and no unsupported future architecture terminology.
+
+No constitution violations require justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/018-catalog-page/
+|-- spec.md
+|-- plan.md
+|-- research.md
+|-- data-model.md
+|-- quickstart.md
+|-- contracts/
+|   `-- catalog-ui.md
+`-- tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+frontend/
+`-- src/
+    `-- app/
+        |-- app.ts
+        |-- app.html
+        |-- app.css
+        |-- catalog/
+        |   `-- catalog-page/
+        |       |-- catalog-page.ts
+        |       |-- catalog-page.html
+        |       |-- catalog-page.css
+        |       `-- catalog-page.spec.ts
+        `-- movies/
+            |-- movie.models.ts
+            |-- movies-api.ts
+            `-- movies-api.spec.ts
+```
+
+**Structure Decision**: Keep API models/services under `frontend/src/app/movies` because movie list/search consumption is reusable by home/catalog/details-adjacent UI. Keep the page under `frontend/src/app/catalog/catalog-page` because catalog orchestration and state are feature-specific.
+
+## Complexity Tracking
+
+No complexity violations.
+
+## Phase 0: Research
+
+Research output: `specs/018-catalog-page/research.md`
+
+Resolved decisions:
+
+- Catalog state uses URL query parameters.
+- `pageSize` defaults to 12, may be read from URL, and has no V1 selector.
+- `/catalog` is public for V1 and does not require route guards.
+- Components use a typed `MoviesApi`; components do not inject `HttpClient`.
+- Invalid URL pagination parameters are normalized before API calls to avoid knowingly issuing invalid requests from the UI.
+- The issue #17 movie card is reused if present; otherwise a catalog-local card is acceptable.
+
+No `NEEDS CLARIFICATION` items remain.
+
+## Phase 1: Design & Contracts
+
+Design outputs:
+
+- `specs/018-catalog-page/data-model.md`
+- `specs/018-catalog-page/contracts/catalog-ui.md`
+- `specs/018-catalog-page/quickstart.md`
+
+Contract summary:
+
+- Frontend consumes `GET /api/movies?page={page}&pageSize={pageSize}`.
+- Frontend consumes `GET /api/movies?query={query}&page={page}&pageSize={pageSize}`.
+- Expected response fields are `items`, `page`, `pageSize`, `totalCount`, `totalPages`, `hasPreviousPage`, and `hasNextPage`.
+- Movie item links target `/movies/{id}` unless issue #13 establishes a different details route before implementation.
+
+Post-design constitution check: pass. The design does not add dependencies, backend behavior, authentication requirements, persistence, or unsupported AI/search architecture.
+
+## Technical Approach
+
+1. Establish Angular routing for `/catalog` and root app navigation.
+2. Add typed movie models for movie summaries, paginated responses, and list query state.
+3. Add `MoviesApi` for `GET /api/movies`, using Angular query parameter construction.
+4. Parse URL query parameters into normalized catalog state:
+   - `query`: trimmed string, omitted when blank.
+   - `page`: positive integer, default `1` when absent or invalid.
+   - `pageSize`: positive integer, default `12` when absent or invalid.
+5. Synchronize search and pagination changes back to URL query parameters.
+6. Load movies from `MoviesApi` and render loading, empty catalog, no-result, error, results, and pagination states.
+7. Link catalog items to the movie details route.
+8. Add focused API service and component tests with mocked API boundaries.
+
+## Affected Areas
+
+- `frontend/src/main.ts`
+- `frontend/src/app/app.ts`
+- `frontend/src/app/app.html`
+- `frontend/src/app/app.css`
+- `frontend/src/app/catalog/catalog-page/*`
+- `frontend/src/app/movies/*`
+- `docs/FRONTEND.md` only if implementation changes documented routing/API structure.
+- `AGENTS.md` Spec Kit current-plan reference.
+
+## Data Model Changes
+
+No backend domain or persistence model changes.
+
+Frontend models are documented in `specs/018-catalog-page/data-model.md`:
+
+- `MovieSummary`
+- `PagedMovieSummaryResponse`
+- `MovieListQuery`
+- `CatalogViewState`
+- `CatalogLoadState`
+
+## API Changes
+
+No API changes are owned by issue #18.
+
+Prerequisite API behavior:
+
+- `GET /api/movies?page=1&pageSize=12`
+- `GET /api/movies?query=central&page=1&pageSize=12`
+- `400 Bad Request` as `application/problem+json` for invalid request parameters.
+- details route target backed by `GET /api/movies/{id}` from issue #13.
+
+Current source still maps only `POST /api/movies`; implementation must confirm issues #12/#16/#13 are complete or explicitly expand scope before relying on runtime API behavior.
+
+## Frontend Changes
+
+- Add public `/catalog` route.
+- Add app navigation entry to Catalog.
+- Add URL-backed catalog state for `query`, `page`, and `pageSize`.
+- Use default `pageSize=12`; no V1 page-size selector.
+- Render movie summaries in a responsive grid/list following `frontend/DESIGN.md`.
+- Render loading, empty catalog, no-result, API error, and pagination states.
+- Reuse issue #17 movie card if available, otherwise use a catalog-local card.
+- Keep UI copy free of unsupported terms: RAG, Qdrant, vector search, semantic search, CLIP, agent framework, recommendations, and AI ranking.
+
+## Backend Changes
+
+None for issue #18.
+
+## Testing Strategy
+
+- `MoviesApi` tests:
+  - builds `GET /api/movies` with `page`, `pageSize`, and optional `query`.
+  - omits blank `query`.
+  - maps the expected paginated response shape.
+- Catalog page tests:
+  - route/app shell renders Catalog navigation.
+  - reads `query`, `page`, and `pageSize` from URL.
+  - defaults invalid or absent `page`/`pageSize` before API calls.
+  - search updates URL state and resets `page` to 1.
+  - pagination updates URL state and respects `hasPreviousPage`/`hasNextPage`.
+  - renders loading, empty catalog, no-result, API error, and success states.
+  - details links target the expected details route.
+
+Verification:
+
+- `npm test -- --watch=false` from `frontend`
+- `npm run build` from `frontend`
+- Run backend build only if prerequisite API contracts are changed as part of a broader scope.
+
+## Deployment Impact
+
+- No new infrastructure.
+- No new frontend dependencies.
+- No new backend dependencies.
+- Uses same-origin `/api` and existing Angular proxy behavior.
+- ASP.NET Core SPA fallback should serve `/catalog` in integrated non-test runtime.
+
+## Security Considerations
+
+- `/catalog` is public for V1 by clarified product decision.
+- Treat URL query parameters and API responses as untrusted.
+- Normalize URL pagination parameters before API calls.
+- Use Angular binding; do not render untrusted HTML.
+- Do not persist bearer tokens or introduce route guards for this feature.
+- Do not expose internal backend errors; show generic API error state.
+
+## Observability / Logging
+
+- No backend logging changes.
+- No frontend production logging of raw API payloads or search terms.
+- User-visible states communicate pending, empty, no-result, and failure conditions.
+
+## Risks
+
+- Issues #12, #16, and #13 may not be implemented when issue #18 starts.
+- Current `PagedResponse<T>` backend contract shape does not match issue #18 expectations.
+- Current Angular app has only the login page and an empty router configuration.
+- Reusable movie card availability depends on issue #17 implementation order.
+
+## Rollout Plan
+
+1. Confirm prerequisite API response shape and details route.
+2. Add typed movie models and `MoviesApi`.
+3. Add public `/catalog` route and navigation.
+4. Implement URL-backed catalog state.
+5. Implement catalog rendering, states, pagination, and details links.
+6. Add focused tests.
+7. Run frontend tests and build.
+8. Update docs only if implementation changes documented frontend structure or API consumption.

--- a/specs/018-catalog-page/quickstart.md
+++ b/specs/018-catalog-page/quickstart.md
@@ -1,0 +1,61 @@
+# Quickstart: Catalog Page
+
+## Prerequisites
+
+- Frontend dependencies installed under `frontend`.
+- Movie listing endpoint from issue #12 available:
+  - `GET /api/movies?page=1&pageSize=12`
+- Basic title search from issue #16 available:
+  - `GET /api/movies?query=central&page=1&pageSize=12`
+- Movie details route from issue #13 agreed or implemented for catalog links.
+
+## Implementation Verification
+
+Run frontend tests:
+
+```powershell
+cd frontend
+npm test -- --watch=false
+```
+
+Run frontend build:
+
+```powershell
+cd frontend
+npm run build
+```
+
+## Manual Browser Checks
+
+Start the frontend through the normal local workflow, then verify:
+
+```text
+/catalog
+/catalog?query=central&page=1&pageSize=12
+/catalog?page=2&pageSize=12
+```
+
+Expected behavior:
+
+- `/catalog` is reachable without frontend authentication.
+- App navigation includes a Catalog link.
+- Catalog shows loading while the API request is pending.
+- Empty catalog state appears when an empty query returns zero total movies.
+- No-result state appears when a non-empty query returns no items.
+- Error state appears when the API request fails.
+- Search updates the URL query string and resets `page` to `1`.
+- Pagination updates the URL query string.
+- `pageSize` defaults to `12` when absent.
+- A valid URL `pageSize` is honored.
+- No page-size selector appears in the V1 UI.
+- Catalog item links target the movie details route.
+
+## Out Of Scope Checks
+
+Implementation should not add:
+
+- Backend list/search/details endpoint code inside issue #18.
+- Route guards or authentication requirements for `/catalog`.
+- Genre/year/AI filters.
+- Semantic search, vector search, RAG, CLIP, recommendations, or AI ranking UI.
+- New UI libraries, state management frameworks, or design systems.

--- a/specs/018-catalog-page/research.md
+++ b/specs/018-catalog-page/research.md
@@ -1,0 +1,67 @@
+# Research: Catalog Page
+
+## Decision: Use URL Query Parameters For Catalog State
+
+**Decision**: Store `query`, `page`, and `pageSize` in `/catalog` URL query parameters.
+
+**Rationale**: The catalog is a primary browsing surface. URL-backed state supports refresh, browser back/forward behavior, and shareable links with minimal extra infrastructure.
+
+**Alternatives considered**:
+
+- Component-only state: rejected because it loses catalog position on refresh and cannot be shared.
+- Hybrid initial URL read only: rejected because later pagination/search changes would still be non-shareable.
+
+## Decision: Default Page Size 12 With No V1 Selector
+
+**Decision**: Default `pageSize` to `12`, honor a valid URL `pageSize`, and do not expose a page-size selector in the V1 UI.
+
+**Rationale**: The GitHub issue suggests `pageSize=12`, which fits a card grid and keeps V1 controls small. Reading URL `pageSize` preserves API flexibility and testability without adding selector UI.
+
+**Alternatives considered**:
+
+- Fixed page size only: rejected because the clarified spec requires reading `pageSize` from the URL.
+- Visible selector: rejected because it adds UI, validation, and acceptance-test scope without a V1 need.
+
+## Decision: Public Catalog Route For V1
+
+**Decision**: `/catalog` is publicly reachable and does not require frontend authentication or route guards in V1.
+
+**Rationale**: Authentication-specific catalog behavior is out of scope, route guards are not implemented, and the current movie create slice is unauthenticated.
+
+**Alternatives considered**:
+
+- Require an authenticated session: rejected because it would introduce auth routing behavior outside issue #18.
+- Defer to future app shell: rejected because the catalog needs a clear implementation target now.
+
+## Decision: Typed API Service Boundary
+
+**Decision**: Add or reuse a typed `MoviesApi` service for `GET /api/movies`; catalog components must not inject `HttpClient` directly.
+
+**Rationale**: Existing frontend auth code isolates HTTP calls in typed API services, and the frontend constitution requires components to avoid owning server concerns.
+
+**Alternatives considered**:
+
+- Direct `HttpClient` in the catalog page: rejected by project rules.
+- Global state management library: rejected because the current dependency set does not include one and the feature does not justify it.
+
+## Decision: Normalize Invalid URL Pagination Parameters Before API Calls
+
+**Decision**: If `page` or `pageSize` URL values are absent, non-numeric, or less than 1, normalize them to defaults before calling the API.
+
+**Rationale**: URL parameters are untrusted input. Normalization avoids knowingly sending malformed requests from the UI while still allowing the API to enforce its own validation for runtime edge cases.
+
+**Alternatives considered**:
+
+- Send invalid URL values to the API: rejected because it creates avoidable error states from client-side URL parsing.
+- Block rendering with a validation page: rejected as too heavy for V1.
+
+## Decision: Reuse Movie Card If Available
+
+**Decision**: Reuse the issue #17 movie card component if it exists by implementation time; otherwise create a catalog-local card that can later be extracted.
+
+**Rationale**: This keeps issue #18 independent of issue #17 ordering while preserving reuse when available.
+
+**Alternatives considered**:
+
+- Block on issue #17: rejected because it makes catalog implementation unnecessarily coupled to card extraction.
+- Create a shared card immediately: rejected unless no reusable component exists and duplication becomes real.

--- a/specs/018-catalog-page/spec.md
+++ b/specs/018-catalog-page/spec.md
@@ -1,0 +1,152 @@
+# Feature Specification
+
+## Feature Summary
+
+Implement a dedicated catalog browsing page at `/catalog` where users can browse movies, run basic title search, page through results, and navigate from a catalog item to the movie details page.
+
+Issue source: https://github.com/marciomyst/SmartMovieCatalog/issues/18
+
+## Clarifications
+
+### Session 2026-05-06
+
+- Q: Should search and pagination state be reflected in the browser URL query string for deep links, or can it remain component state for V1? -> A: Use URL query params, for example `/catalog?query=central&page=2&pageSize=12`.
+- Q: Should the catalog expose a fixed page size of 12, as suggested by the issue, or offer a page-size selector? -> A: Read `pageSize` from the URL but do not expose a page-size selector.
+- Q: Should `/catalog` be publicly reachable for V1 or require an authenticated frontend session? -> A: `/catalog` is publicly reachable for V1.
+
+## Problem Statement
+
+The application currently does not provide a dedicated catalog surface outside the home page. Users need a stable route for browsing all movies, searching by title, handling result states, and opening movie details.
+
+## Goals
+
+- Add a catalog route/page reachable from app navigation.
+- Fetch paginated movie summaries through the movie listing API.
+- Integrate basic title search using `GET /api/movies?query=...&page=...&pageSize=...`.
+- Display movies in cards or a consistent catalog layout aligned with the dark cinematic frontend design system.
+- Support loading, empty catalog, no-result, API error, and pagination states.
+- Link each catalog item to the movie details route.
+- Keep the page responsive across mobile and desktop.
+- Keep implementation scoped to V1 catalog browsing without unsupported AI or advanced search terminology.
+
+## Non-Goals
+
+- Genre filtering.
+- Year filtering.
+- AI analyzed filtering.
+- Semantic search.
+- Vector search.
+- Recommendations.
+- Poster similarity.
+- RAG.
+- Authentication-specific catalog behavior.
+- New UI libraries, state management frameworks, or design systems.
+- Backend implementation of prerequisite movie list, search, or details endpoints unless those prerequisite issues are explicitly folded into the work.
+
+## User Stories
+
+- As a catalog user, I want to open a dedicated catalog page so that I can browse movies outside the home page.
+- As a catalog user, I want to search movies by title so that I can find a specific movie quickly.
+- As a catalog user, I want pagination controls so that I can move through large result sets deliberately.
+- As a catalog user, I want clear loading, empty, no-result, and error states so that I understand what is happening.
+- As a catalog user, I want to open a movie details page from a catalog item so that I can inspect full metadata.
+
+## Functional Requirements
+
+- The frontend MUST define a `/catalog` route.
+- The catalog page MUST be reachable through app navigation.
+- The catalog page MUST be publicly reachable in V1 and MUST NOT require frontend authentication or route guards.
+- The catalog page MUST call a typed frontend API service rather than calling `HttpClient` directly from components.
+- The typed API service MUST consume `GET /api/movies` with `query`, `page`, and `pageSize` parameters.
+- The catalog page MUST display movie summaries returned by the API.
+- The catalog page MUST support a basic title search input.
+- The catalog page MUST synchronize `query`, `page`, and `pageSize` with URL query parameters so catalog state survives refreshes and supports shareable links.
+- The catalog page MUST default to `pageSize=12` when no page size is present in the URL.
+- The catalog page MUST honor a valid `pageSize` from the URL but MUST NOT expose a page-size selector in the V1 UI.
+- Empty search query MUST return the default movie list behavior provided by the listing API.
+- Search MUST remain basic title search and MUST NOT expose semantic, vector, RAG, CLIP, AI ranking, or recommendation behavior.
+- The page MUST display a loading state while requests are pending.
+- The page MUST display an empty catalog state when the API returns zero total movies for an empty query.
+- The page MUST display a no-result state when the API returns zero items for a non-empty query.
+- The page MUST display an API error state when the request fails.
+- The page MUST provide explicit pagination controls driven by `page`, `pageSize`, `totalCount`, `totalPages`, `hasPreviousPage`, and `hasNextPage`.
+- Pagination controls MUST not allow navigation before the first page or beyond the last page.
+- Catalog items MUST navigate to the movie details route backed by issue #13.
+- Catalog layout MUST be responsive and follow `frontend/DESIGN.md`.
+- Reusable movie card behavior from issue #17 SHOULD be reused if it exists by implementation time.
+- Components MUST keep server communication in typed API services and strongly typed models.
+
+## Acceptance Criteria
+
+- Catalog page is reachable through app navigation.
+- Catalog page lists movies from the API.
+- Catalog page consumes the paginated movie list endpoint from issue #12.
+- Catalog page integrates title search from issue #16.
+- User can navigate from catalog item to movie details.
+- Catalog item navigation targets the movie details route backed by issue #13.
+- Catalog page handles loading state.
+- Catalog page handles empty catalog state.
+- Catalog page handles no search results state.
+- Catalog page handles API error state.
+- Pagination controls work consistently using `page`, `pageSize`, `totalCount`, `totalPages`, `hasPreviousPage`, and `hasNextPage`.
+- Layout is responsive.
+- Components use typed API services instead of direct `HttpClient`.
+- No unsupported future architecture terms are shown in the UI.
+
+## Edge Cases
+
+- API returns zero items and zero total count for an empty query.
+- API returns zero items for a non-empty query.
+- API returns an invalid request problem response for invalid pagination or query parameters.
+- User changes the search term while a request is in flight.
+- User pages after a search query changes.
+- User opens `/catalog` with URL query parameters for `query`, `page`, or `pageSize`.
+- User opens `/catalog` with an invalid `pageSize` query parameter.
+- User lands on a page number that no longer has results after data changes.
+- API returns partial optional movie metadata such as missing `director`, `genres`, or `posterUrl`.
+- Movie card component from issue #17 is unavailable at implementation time.
+- Details route from issue #13 is unavailable at implementation time.
+
+## Clarifications Needed
+
+None identified.
+
+## Assumptions
+
+- Issue #12 will provide `GET /api/movies` with the shared paginated movie summary response before issue #18 implementation is completed.
+- Issue #16 will provide basic title search through the same listing endpoint before issue #18 implementation is completed.
+- Issue #13 will provide the movie details route before catalog item navigation is completed.
+- Issue #17 will provide a reusable movie card component if it is implemented first; otherwise issue #18 may create a small catalog item/card component within the catalog feature boundary.
+- The default page size is 12 when `pageSize` is absent from the URL.
+- Catalog search and pagination state use URL query parameters for V1.
+- Catalog browsing is public for V1.
+
+## Dependencies
+
+- Issue #12: List movies.
+- Issue #16: Basic title search.
+- Issue #13: View movie details.
+- Issue #17: Movie cards on the home page, optional reuse dependency.
+- Existing Angular 21 frontend in `frontend`.
+- Existing same-origin `/api` proxy behavior documented in `docs/FRONTEND.md`.
+- Existing design system in `frontend/DESIGN.md`.
+
+## Risks
+
+- The current source only maps `POST /api/movies`; `GET /api/movies` and `GET /api/movies/{id}` are not present yet.
+- The current `SmartMovieCatalog.Contracts.Common.PagedResponse<T>` uses `PageNumber` and lacks `totalPages`, `hasPreviousPage`, and `hasNextPage`, which conflicts with the issue #12/#16/#18 expected response shape.
+- The current root Angular app renders only the login page and has an empty router configuration, so navigation and route layout work may be larger than a single page component if not delivered by prerequisite issues.
+- Reusing issue #17 movie card depends on implementation order.
+
+## Conflicts
+
+- `docs/API.md` currently documents only `POST /api/movies`, while issue #18 requires consuming `GET /api/movies` from issue #12 and title search from issue #16.
+- Current `PagedResponse<T>` source shape does not match the paginated response shape required by issue #18. This should be resolved by issue #12/#16 or explicitly included before implementation of this page.
+
+## Out of Scope
+
+- Implementing advanced catalog filters.
+- Implementing semantic, vector, RAG, AI ranking, or recommendation search.
+- Adding authentication-specific behavior to catalog browsing.
+- Adding poster upload or poster similarity.
+- Changing backend architecture, persistence provider, authentication model, or frontend design system.

--- a/specs/018-catalog-page/tasks.md
+++ b/specs/018-catalog-page/tasks.md
@@ -1,0 +1,261 @@
+# Tasks: Catalog Page
+
+**Input**: Design documents from `specs/018-catalog-page/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/catalog-ui.md`, `quickstart.md`
+**Tests**: Included because `plan.md` requires focused frontend API service and catalog page tests.
+**Scope**: Frontend implementation for issue #18. Backend list/search/details endpoints from issues #12, #16, and #13 remain prerequisites unless scope is explicitly expanded.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel because it touches different files or has no dependency on incomplete tasks.
+- **[Story]**: Maps to the user stories in `spec.md`.
+- Every task includes an exact repository path.
+
+---
+
+## Phase 1: Setup (Shared Context)
+
+**Purpose**: Confirm the refreshed issue #18 planning context and current frontend structure before implementation.
+
+- [X] T001 Review clarified decisions in `specs/018-catalog-page/spec.md`
+- [X] T002 [P] Review URL/query and public-route decisions in `specs/018-catalog-page/research.md`
+- [X] T003 [P] Review frontend model definitions in `specs/018-catalog-page/data-model.md`
+- [X] T004 [P] Review UI/API contract requirements in `specs/018-catalog-page/contracts/catalog-ui.md`
+- [X] T005 [P] Review manual verification expectations in `specs/018-catalog-page/quickstart.md`
+- [X] T006 Inspect current Angular bootstrap and router setup in `frontend/src/main.ts`
+- [X] T007 [P] Inspect current root app shell files in `frontend/src/app/app.ts`, `frontend/src/app/app.html`, and `frontend/src/app/app.css`
+- [X] T008 [P] Inspect existing frontend HTTP test pattern in `frontend/src/app/auth/auth-api.spec.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared movie API models and service infrastructure needed by every catalog user story.
+
+**Critical**: No catalog page story can be completed until this phase is complete.
+
+- [X] T009 Create `MovieSummary`, `PagedMovieSummaryResponse`, `MovieListQuery`, `CatalogViewState`, and `CatalogLoadState` in `frontend/src/app/movies/movie.models.ts`
+- [X] T010 Implement typed `MoviesApi.listMovies()` for `GET /api/movies` in `frontend/src/app/movies/movies-api.ts`
+- [X] T011 [P] Add `MoviesApi` test for `page`, `pageSize`, and non-empty `query` parameters in `frontend/src/app/movies/movies-api.spec.ts`
+- [X] T012 [P] Add `MoviesApi` test that blank `query` is omitted from the request in `frontend/src/app/movies/movies-api.spec.ts`
+- [X] T013 [P] Add `MoviesApi` test for the expected paginated response shape in `frontend/src/app/movies/movies-api.spec.ts`
+
+**Checkpoint**: Typed API access exists, and catalog components can consume movie summaries without direct `HttpClient` usage.
+
+---
+
+## Phase 3: User Story 1 - Open Dedicated Catalog Page (Priority: P1) MVP
+
+**Goal**: A user can navigate to public `/catalog` and see a dedicated catalog browsing surface.
+
+**Independent Test**: Navigate to `/catalog` without an authenticated frontend session and verify the Catalog page renders with the app navigation.
+
+### Tests for User Story 1
+
+- [X] T014 [P] [US1] Add app-shell test for a Catalog navigation link in `frontend/src/app/app.spec.ts`
+- [X] T015 [P] [US1] Add route test proving `/catalog` renders without an auth guard in `frontend/src/app/app.spec.ts`
+- [X] T016 [P] [US1] Add initial catalog page render test in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+
+### Implementation for User Story 1
+
+- [X] T017 [US1] Register the public `/catalog` route using Angular router providers in `frontend/src/main.ts`
+- [X] T018 [US1] Update root app imports and router outlet support in `frontend/src/app/app.ts`
+- [X] T019 [US1] Add fixed top navigation with a Catalog link and router outlet in `frontend/src/app/app.html`
+- [X] T020 [US1] Style the app shell and active Catalog navigation state using `frontend/DESIGN.md` tokens in `frontend/src/app/app.css`
+- [X] T021 [US1] Create the catalog page component class with initial load state in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T022 [US1] Create base catalog page markup with title, search area, result area, and pagination area in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+- [X] T023 [US1] Style the base catalog layout responsively in `frontend/src/app/catalog/catalog-page/catalog-page.css`
+
+**Checkpoint**: `/catalog` is publicly reachable through app navigation and renders a responsive page skeleton.
+
+---
+
+## Phase 4: User Story 2 - Browse Movies From API (Priority: P2)
+
+**Goal**: A user can browse movie summaries loaded from the API.
+
+**Independent Test**: Mock `MoviesApi` with movie summaries and verify the catalog page renders titles and metadata without direct `HttpClient` usage.
+
+### Tests for User Story 2
+
+- [X] T024 [P] [US2] Add catalog success-state test with mocked movie summaries in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+- [X] T025 [P] [US2] Add test proving catalog page uses `MoviesApi` and not component `HttpClient` setup in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+
+### Implementation for User Story 2
+
+- [X] T026 [US2] Inject and call `MoviesApi` from the catalog page in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T027 [US2] Render movie summary cards or list items from API data in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+- [X] T028 [US2] Add responsive movie grid/list styles aligned with `frontend/DESIGN.md` in `frontend/src/app/catalog/catalog-page/catalog-page.css`
+- [X] T029 [US2] Reuse the issue #17 movie card if present, otherwise keep catalog-local card markup in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+
+**Checkpoint**: The catalog page lists movies from the typed API service and remains testable with mocked data.
+
+---
+
+## Phase 5: User Story 3 - Search Movies By Title With URL State (Priority: P3)
+
+**Goal**: A user can search movies by title and share/refresh the resulting catalog URL.
+
+**Independent Test**: Open `/catalog?query=central&page=2&pageSize=12`, verify the page reads URL state, then search for a new query and verify the URL updates with `page=1`.
+
+### Tests for User Story 3
+
+- [X] T030 [P] [US3] Add test that catalog reads initial `query`, `page`, and `pageSize` from URL query parameters in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+- [X] T031 [P] [US3] Add search test that updates URL query parameters and resets `page` to `1` in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+- [X] T032 [P] [US3] Add test that blank search omits `query` from API request and URL state in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+
+### Implementation for User Story 3
+
+- [X] T033 [US3] Parse `query`, `page`, and `pageSize` from `ActivatedRoute` query parameters in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T034 [US3] Add search form state and submission handling in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T035 [US3] Synchronize search changes to router query parameters in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T036 [US3] Wire the search input and submit action to catalog search in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+- [X] T037 [US3] Style the search input and action state according to `frontend/DESIGN.md` in `frontend/src/app/catalog/catalog-page/catalog-page.css`
+
+**Checkpoint**: Basic title search is URL-backed, shareable, refresh-safe, and free of semantic/AI search terminology.
+
+---
+
+## Phase 6: User Story 4 - Use Explicit Pagination And Catalog States (Priority: P4)
+
+**Goal**: A user sees clear loading, empty, no-result, error, and pagination states driven by API metadata.
+
+**Independent Test**: Mock loading, empty catalog, no-result, API failure, previous-page, and next-page responses and verify visible states, disabled controls, and URL updates.
+
+### Tests for User Story 4
+
+- [X] T038 [P] [US4] Add catalog loading, empty catalog, no-result, and error state tests in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+- [X] T039 [P] [US4] Add pagination tests for `hasPreviousPage`, `hasNextPage`, and URL updates in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+- [X] T040 [P] [US4] Add invalid URL `page` and `pageSize` normalization tests in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+
+### Implementation for User Story 4
+
+- [X] T041 [US4] Implement `loading`, `success`, `emptyCatalog`, `noResults`, and `error` load state derivation in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T042 [US4] Normalize absent or invalid URL `page` to `1` and `pageSize` to `12` before API calls in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T043 [US4] Implement previous and next pagination handlers that update router query parameters in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T044 [US4] Render loading, empty catalog, no-result, and generic API error states in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+- [X] T045 [US4] Render pagination controls using `page`, `pageSize`, `totalCount`, `totalPages`, `hasPreviousPage`, and `hasNextPage` in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+- [X] T046 [US4] Ensure no page-size selector is rendered in V1 in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+- [X] T047 [US4] Style catalog states and pagination controls responsively in `frontend/src/app/catalog/catalog-page/catalog-page.css`
+
+**Checkpoint**: Catalog state handling, invalid URL normalization, and explicit pagination are complete and testable.
+
+---
+
+## Phase 7: User Story 5 - Navigate To Movie Details (Priority: P5)
+
+**Goal**: A user can open a movie details page from a catalog item.
+
+**Independent Test**: Render a movie item and verify its link targets `/movies/{id}` unless issue #13 establishes a different route first.
+
+### Tests for User Story 5
+
+- [X] T048 [P] [US5] Add catalog item details-link test for `/movies/{id}` in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`
+
+### Implementation for User Story 5
+
+- [X] T049 [US5] Add details route link generation for each catalog item in `frontend/src/app/catalog/catalog-page/catalog-page.ts`
+- [X] T050 [US5] Apply details navigation links to catalog item markup in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+- [X] T051 [US5] Add accessible focus and hover styles for catalog item navigation in `frontend/src/app/catalog/catalog-page/catalog-page.css`
+
+**Checkpoint**: Each catalog item navigates to the movie details route without adding details-page behavior to issue #18.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate the complete frontend slice against the refreshed plan, quickstart, and acceptance criteria.
+
+- [X] T052 [P] Check visible catalog UI copy for unsupported terms in `frontend/src/app/catalog/catalog-page/catalog-page.html`
+- [X] T053 [P] Verify manual scenarios from `specs/018-catalog-page/quickstart.md`
+- [X] T054 [P] Update frontend documentation if routing or API consumption structure changed in `docs/FRONTEND.md`
+- [X] T055 Run frontend unit tests with `npm test -- --watch=false` from `frontend/package.json`
+- [X] T056 Run frontend build with `npm run build` from `frontend/package.json`
+- [X] T057 Review implementation against issue #18 acceptance criteria in `specs/018-catalog-page/spec.md`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup and blocks all user stories.
+- **US1 Dedicated Catalog Route (Phase 3)**: Depends on Foundational.
+- **US2 API-Backed Browsing (Phase 4)**: Depends on Foundational and works best after US1 route shell.
+- **US3 URL-Backed Search (Phase 5)**: Depends on US2 API loading and US1 routing.
+- **US4 States And Pagination (Phase 6)**: Depends on US3 URL state and US2 response handling.
+- **US5 Details Navigation (Phase 7)**: Depends on US2 rendered catalog items and issue #13 route availability.
+- **Polish (Phase 8)**: Depends on all selected stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational and provides the MVP route.
+- **US2 (P2)**: Can start after Foundational; needs the typed `MoviesApi`.
+- **US3 (P3)**: Depends on catalog route and API loading.
+- **US4 (P4)**: Depends on URL state and API response metadata.
+- **US5 (P5)**: Depends on rendered movie items and the details route contract.
+
+### Parallel Opportunities
+
+- T002, T003, T004, T005, T007, and T008 can run in parallel during setup.
+- T011, T012, and T013 can run in parallel after `MoviesApi` shape is defined.
+- Tests marked `[P]` within each user story can be written in parallel before implementation.
+- CSS tasks can usually proceed after related markup exists while TypeScript state work continues.
+
+---
+
+## Parallel Example: User Story 3
+
+```text
+Task: "T030 [P] [US3] Add test that catalog reads initial query, page, and pageSize from URL query parameters in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+Task: "T031 [P] [US3] Add search test that updates URL query parameters and resets page to 1 in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+Task: "T032 [P] [US3] Add test that blank search omits query from API request and URL state in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+```
+
+---
+
+## Parallel Example: User Story 4
+
+```text
+Task: "T038 [P] [US4] Add catalog loading, empty catalog, no-result, and error state tests in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+Task: "T039 [P] [US4] Add pagination tests for hasPreviousPage, hasNextPage, and URL updates in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+Task: "T040 [P] [US4] Add invalid URL page and pageSize normalization tests in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Phase 1 and Phase 2.
+2. Complete US1 to make public `/catalog` reachable.
+3. Complete US2 to list API-backed movies.
+4. Stop and validate with mocked API data before adding URL-backed search, full state handling, pagination, and details navigation.
+
+### Incremental Delivery
+
+1. Route shell and public navigation.
+2. Typed API service and API-backed browsing.
+3. URL-backed basic title search.
+4. Loading/empty/no-result/error states and pagination.
+5. Details navigation.
+6. Tests, build, quickstart verification, and documentation check.
+
+### Validation
+
+- Run `npm test -- --watch=false` from `frontend`.
+- Run `npm run build` from `frontend`.
+- If prerequisite API contracts are changed outside issue #18, run the relevant backend build from `SmartMovieCatalog.slnx` or `backend/src/SmartMovieCatalog.Api/SmartMovieCatalog.Api.csproj`.
+
+---
+
+## Notes
+
+- Do not implement backend list/search/details endpoints inside issue #18 unless scope is explicitly expanded.
+- Do not add route guards or require authentication for `/catalog` in V1.
+- Do not render a page-size selector in V1.
+- Components must consume `MoviesApi`; they must not inject `HttpClient` directly.
+- Keep search as basic title search only.
+- Keep UI copy free of unsupported V1 terms such as RAG, Qdrant, vector search, semantic search, CLIP, agent framework, recommendations, and AI ranking.


### PR DESCRIPTION
## Summary

- add the public /catalog route and navigation shell
- add typed movie list models and MoviesApi for paginated title search
- add catalog UI states, URL-backed query/page/pageSize handling, pagination, and details links
- add Spec Kit artifacts for issue #18 and update frontend docs
- update frontend lockfile to resolve the transitive express-rate-limit/ip-address audit warning

## Validation

- npm test -- --watch=false
- npm run build
- npm audit --audit-level=moderate

## Notes

Backend movie list/search/details endpoints remain prerequisite work from issues #12, #16, and #13.