### PR TITLE
[codex] View movie details

### DIFF
--- a/.specify/inputs/github-issues/13-view-movie-details.md
+++ b/.specify/inputs/github-issues/13-view-movie-details.md
@@ -1,0 +1,161 @@
+﻿# GitHub Issue Context
+
+## Source
+
+- Repository: marciomyst/SmartMovieCatalog
+- Issue: #13
+- URL: https://github.com/marciomyst/SmartMovieCatalog/issues/13
+- State: OPEN
+- Created: 2026-05-02T22:42:32Z
+- Updated: 2026-05-02T22:58:10Z
+- Milestone: M1 — Core Movie Catalog
+
+## Title
+
+View movie details
+
+## Labels
+
+- type:feature
+- priority:high
+- area:api
+- area:backend
+- area:frontend
+- area:catalog
+- v1
+
+## Assignees
+
+_No assignees_
+
+
+
+## Issue Body
+
+## Summary
+
+Implement the movie details API and frontend details view.
+
+This issue allows users to open a specific movie from a list or card and see its full metadata.
+
+## Goal
+
+Allow users to view the full details of a single movie.
+
+## Scope
+
+- Add an API endpoint to get a movie by ID.
+- Return a detail DTO with the full movie metadata currently supported.
+- Add a frontend details route/page.
+- Add navigation from movie cards/list items to the details page.
+- Handle loading, not found, and error states.
+- Keep the UI aligned with the dark cinematic product direction.
+
+## Suggested API
+
+```http
+GET /api/movies/{id}
+```
+
+Response media type:
+
+```http
+application/json
+```
+
+Example response shape:
+
+```json
+{
+  "id": "movie-id",
+  "title": "Central do Brasil",
+  "originalTitle": "Central do Brasil",
+  "releaseYear": 1998,
+  "countryCode": "BR",
+  "originalLanguage": "pt-BR",
+  "genres": ["Drama"],
+  "director": "Walter Salles",
+  "cast": [],
+  "synopsis": "A retired teacher and a young boy travel through Brazil in search of his father.",
+  "durationMinutes": 110,
+  "ageRating": "12",
+  "posterUrl": null,
+  "createdAt": "2026-05-02T00:00:00Z",
+  "updatedAt": null
+}
+```
+
+Example not found response:
+
+```http
+HTTP/1.1 404 Not Found
+Content-Type: application/problem+json
+```
+
+```json
+{
+  "type": "https://smartmoviecatalog.dev/problems/movie-not-found",
+  "title": "Movie not found.",
+  "status": 404,
+  "detail": "The movie with id '8b9c2b58-3f8e-48f6-ae0c-6b77f4f274b1' was not found.",
+  "instance": "/api/movies/8b9c2b58-3f8e-48f6-ae0c-6b77f4f274b1"
+}
+```
+
+## Acceptance Criteria
+
+- A movie can be retrieved by ID.
+- Existing movie returns `200 OK`.
+- Successful response uses the `application/json` media type.
+- Missing movie returns `404 Not Found`.
+- Missing movie response uses `application/problem+json` with `type`, `title`, `status`, `detail`, and `instance`.
+- The details page displays title, year, genres, director, synopsis, duration, age rating, and available metadata.
+- The UI handles loading state.
+- The UI handles not found state.
+- The UI handles API failure state.
+- Navigation from movie card/list to details works.
+- No persistence model is exposed directly through the API.
+
+## Technical Notes
+
+- Use a dedicated detail response DTO.
+- Use simple HTTP JSON contracts for request and response payloads.
+- Use `application/problem+json` for not found failures.
+- Do not include AI analysis fields until the AI analysis feature exists.
+- Do not introduce edit behavior in this issue unless needed only as navigation to the edit flow.
+
+## Out of Scope
+
+- Editing movie data.
+- Poster upload.
+- AI poster analysis.
+- Realtime updates.
+- Similar movie recommendations.
+- Semantic search.
+
+
+## Comments
+
+_No comments_
+
+## Instructions for Spec Kit
+
+Use this GitHub issue as the primary source of truth.
+
+Convert the issue into a Spec Kit feature specification before creating the implementation plan.
+
+Preserve:
+
+- business goal;
+- user stories;
+- acceptance criteria;
+- technical constraints;
+- non-goals;
+- dependencies;
+- open questions.
+
+If information is missing, add it under a clearly marked **Clarifications Needed** section instead of inventing requirements.
+
+If the issue conflicts with existing project documentation, explicitly call out the conflict.
+
+Prefer a small, incremental implementation plan aligned with the repository's existing architecture, folder structure, language, framework, and conventions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ Do not read, modify, or base analysis on generated/vendor output unless explicit
   - `test:`
 
 <!-- SPECKIT START -->
-Current Spec Kit plan: `specs/025-normalize-movie-genres/plan.md`.
+Current Spec Kit plan: `specs/013-view-movie-details/plan.md`.
 
 Before using Spec Kit skills, read `.specify/memory/constitution.md`.
 If the spec, plan, or implementation touches backend, API, contracts, domain,

--- a/SmartMovieCatalog.slnx
+++ b/SmartMovieCatalog.slnx
@@ -5,15 +5,15 @@
     <Project Path="backend/src/SmartMovieCatalog.Contracts/SmartMovieCatalog.Contracts.csproj" />
     <Project Path="backend/src/SmartMovieCatalog.Domain/SmartMovieCatalog.Domain.csproj" />
     <Project Path="backend/src/SmartMovieCatalog.Infrastructure/SmartMovieCatalog.Infrastructure.csproj" />
+    <Project Path="frontend/Smartmoviecatalog.Angular.esproj">
+      <Build />
+      <Deploy />
+    </Project>
   </Folder>
   <Folder Name="/tests/">
     <Project Path="backend/tests/SmartMovieCatalog.Api.Tests/SmartMovieCatalog.Api.Tests.csproj" />
     <Project Path="backend/tests/SmartMovieCatalog.Application.Tests/SmartMovieCatalog.Application.Tests.csproj" />
     <Project Path="backend/tests/SmartMovieCatalog.Domain.Tests/SmartMovieCatalog.Domain.Tests.csproj" />
     <Project Path="backend/tests/SmartMovieCatalog.Infrastructure.Tests/SmartMovieCatalog.Infrastructure.Tests.csproj" />
-    <Project Path="frontend/Smartmoviecatalog.Angular.esproj">
-      <Build />
-      <Deploy />
-    </Project>
   </Folder>
 </Solution>

--- a/backend/src/SmartMovieCatalog.Api/Features/Movies/GetMovieById/GetMovieByIdEndpoint.cs
+++ b/backend/src/SmartMovieCatalog.Api/Features/Movies/GetMovieById/GetMovieByIdEndpoint.cs
@@ -1,0 +1,92 @@
+using Microsoft.AspNetCore.Mvc;
+using SmartMovieCatalog.Application;
+using SmartMovieCatalog.Application.Features.Movies;
+using SmartMovieCatalog.Contracts.Movies;
+using Wolverine;
+
+namespace SmartMovieCatalog.Api.Features.Movies.GetMovieById;
+
+public static class GetMovieByIdEndpoint
+{
+    public static void MapGetMovieById(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/movies/{id}", HandleAsync)
+            .WithName("GetMovieById")
+            .WithTags("Movies")
+            .AllowAnonymous()
+            .Produces<MovieDetailsResponse>(StatusCodes.Status200OK)
+            .Produces<ProblemDetails>(StatusCodes.Status400BadRequest, "application/problem+json")
+            .Produces<ProblemDetails>(StatusCodes.Status404NotFound, "application/problem+json");
+    }
+
+    private static async Task<IResult> HandleAsync(
+        string id,
+        HttpContext httpContext,
+        IMessageBus messageBus,
+        CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(id, out Guid movieId))
+        {
+            return Results.Json(
+                CreateInvalidMovieIdProblem(httpContext),
+                statusCode: StatusCodes.Status400BadRequest,
+                contentType: "application/problem+json");
+        }
+
+        Result<MovieDetails, GetMovieByIdFailure> result =
+            await messageBus.InvokeAsync<Result<MovieDetails, GetMovieByIdFailure>>(
+                new GetMovieByIdQuery(movieId),
+                cancellationToken);
+
+        return result.Match<IResult>(
+            details => Results.Ok(new MovieDetailsResponse(
+                details.Id.ToString(),
+                details.Title,
+                details.OriginalTitle,
+                details.ReleaseYear,
+                details.CountryCode,
+                details.OriginalLanguage,
+                details.Genres,
+                details.Director,
+                details.Synopsis,
+                details.DurationMinutes,
+                details.AgeRating,
+                details.ExternalId,
+                details.PosterUrl,
+                details.CreatedAt)),
+            _ => Results.Json(
+                CreateMovieNotFoundProblem(httpContext, id),
+                statusCode: StatusCodes.Status404NotFound,
+                contentType: "application/problem+json"));
+    }
+
+    private static ProblemDetails CreateInvalidMovieIdProblem(HttpContext httpContext)
+    {
+        ProblemDetails problemDetails = new()
+        {
+            Status = StatusCodes.Status400BadRequest,
+            Title = "Invalid movie id.",
+            Detail = "Movie id must be a valid GUID.",
+            Type = "https://smartmoviecatalog/problems/invalid-movie-id",
+            Instance = httpContext.Request.Path
+        };
+
+        problemDetails.Extensions["traceId"] = httpContext.TraceIdentifier;
+        return problemDetails;
+    }
+
+    private static ProblemDetails CreateMovieNotFoundProblem(HttpContext httpContext, string id)
+    {
+        ProblemDetails problemDetails = new()
+        {
+            Status = StatusCodes.Status404NotFound,
+            Title = "Movie not found.",
+            Detail = $"Movie '{id}' was not found.",
+            Type = "https://smartmoviecatalog/problems/movie-not-found",
+            Instance = httpContext.Request.Path
+        };
+
+        problemDetails.Extensions["traceId"] = httpContext.TraceIdentifier;
+        return problemDetails;
+    }
+}

--- a/backend/src/SmartMovieCatalog.Api/Features/Movies/MoviesEndpoints.cs
+++ b/backend/src/SmartMovieCatalog.Api/Features/Movies/MoviesEndpoints.cs
@@ -1,4 +1,5 @@
 using SmartMovieCatalog.Api.Features.Movies.CreateMovie;
+using SmartMovieCatalog.Api.Features.Movies.GetMovieById;
 using SmartMovieCatalog.Api.Features.Movies.ListMovies;
 
 namespace SmartMovieCatalog.Api.Features.Movies;
@@ -8,6 +9,7 @@ public static class MoviesEndpoints
     public static void MapMovieEndpoints(this IEndpointRouteBuilder app)
     {
         app.MapListMovies();
+        app.MapGetMovieById();
         app.MapCreateMovie();
     }
 }

--- a/backend/src/SmartMovieCatalog.Application/Abstractions/Persistence/IMovieRepository.cs
+++ b/backend/src/SmartMovieCatalog.Application/Abstractions/Persistence/IMovieRepository.cs
@@ -6,6 +6,8 @@ public interface IMovieRepository
 {
     Task AddAsync(Movie movie, CancellationToken cancellationToken);
 
+    Task<Movie?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+
     Task<PagedResult<Movie>> ListAsync(
         string? query,
         int page,

--- a/backend/src/SmartMovieCatalog.Application/Features/Movies/GetMovieByIdFailure.cs
+++ b/backend/src/SmartMovieCatalog.Application/Features/Movies/GetMovieByIdFailure.cs
@@ -1,0 +1,6 @@
+namespace SmartMovieCatalog.Application.Features.Movies;
+
+public enum GetMovieByIdFailure
+{
+    NotFound = 1
+}

--- a/backend/src/SmartMovieCatalog.Application/Features/Movies/GetMovieByIdHandler.cs
+++ b/backend/src/SmartMovieCatalog.Application/Features/Movies/GetMovieByIdHandler.cs
@@ -1,0 +1,44 @@
+using SmartMovieCatalog.Application.Abstractions.Persistence;
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Application.Features.Movies;
+
+public sealed class GetMovieByIdHandler
+{
+    private readonly IMovieRepository _movieRepository;
+
+    public GetMovieByIdHandler(IMovieRepository movieRepository)
+    {
+        _movieRepository = movieRepository;
+    }
+
+    public async Task<Result<MovieDetails, GetMovieByIdFailure>> Handle(
+        GetMovieByIdQuery query,
+        CancellationToken cancellationToken)
+    {
+        Movie? movie = await _movieRepository.GetByIdAsync(query.Id, cancellationToken);
+        if (movie is null)
+        {
+            return Result<MovieDetails, GetMovieByIdFailure>.Failure(GetMovieByIdFailure.NotFound);
+        }
+
+        return Result<MovieDetails, GetMovieByIdFailure>.Success(new MovieDetails(
+            movie.Id,
+            movie.Title,
+            movie.OriginalTitle,
+            movie.ReleaseYear,
+            movie.CountryCode,
+            movie.OriginalLanguage,
+            movie.Genres
+                .Select(movieGenre => movieGenre.Genre.Name)
+                .Order(StringComparer.Ordinal)
+                .ToArray(),
+            movie.Director,
+            movie.Synopsis,
+            movie.DurationMinutes,
+            movie.AgeRating,
+            movie.ExternalId,
+            movie.Image,
+            movie.CreatedAtUtc));
+    }
+}

--- a/backend/src/SmartMovieCatalog.Application/Features/Movies/GetMovieByIdQuery.cs
+++ b/backend/src/SmartMovieCatalog.Application/Features/Movies/GetMovieByIdQuery.cs
@@ -1,0 +1,3 @@
+namespace SmartMovieCatalog.Application.Features.Movies;
+
+public sealed record GetMovieByIdQuery(Guid Id);

--- a/backend/src/SmartMovieCatalog.Application/Features/Movies/MovieDetails.cs
+++ b/backend/src/SmartMovieCatalog.Application/Features/Movies/MovieDetails.cs
@@ -1,0 +1,17 @@
+namespace SmartMovieCatalog.Application.Features.Movies;
+
+public sealed record MovieDetails(
+    Guid Id,
+    string Title,
+    string? OriginalTitle,
+    int ReleaseYear,
+    string CountryCode,
+    string OriginalLanguage,
+    IReadOnlyCollection<string> Genres,
+    string? Director,
+    string? Synopsis,
+    int? DurationMinutes,
+    string? AgeRating,
+    int? ExternalId,
+    string? PosterUrl,
+    DateTimeOffset CreatedAt);

--- a/backend/src/SmartMovieCatalog.Contracts/Movies/MovieDetailsResponse.cs
+++ b/backend/src/SmartMovieCatalog.Contracts/Movies/MovieDetailsResponse.cs
@@ -1,0 +1,17 @@
+namespace SmartMovieCatalog.Contracts.Movies;
+
+public sealed record MovieDetailsResponse(
+    string Id,
+    string Title,
+    string? OriginalTitle,
+    int ReleaseYear,
+    string CountryCode,
+    string OriginalLanguage,
+    IReadOnlyCollection<string> Genres,
+    string? Director,
+    string? Synopsis,
+    int? DurationMinutes,
+    string? AgeRating,
+    int? ExternalId,
+    string? PosterUrl,
+    DateTimeOffset CreatedAt);

--- a/backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs
+++ b/backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs
@@ -18,6 +18,15 @@ public sealed class EfMovieRepository : IMovieRepository
         await _dbContext.Movies.AddAsync(movie, cancellationToken);
     }
 
+    public Task<Movie?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.Movies
+            .AsNoTracking()
+            .Include(movie => movie.Genres)
+            .ThenInclude(movieGenre => movieGenre.Genre)
+            .SingleOrDefaultAsync(movie => movie.Id == id, cancellationToken);
+    }
+
     public async Task<PagedResult<Movie>> ListAsync(
         string? query,
         int page,

--- a/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointContractTests.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/Movies/CreateMovieEndpointContractTests.cs
@@ -55,7 +55,7 @@ public sealed class CreateMovieEndpointContractTests : IClassFixture<SmartMovieC
     }
 
     [Fact]
-    public async Task CreateMovie_ReturnsFutureLocationWithoutReadEndpoint()
+    public async Task CreateMovie_LocationPointsToReadableResource()
     {
         HttpClient client = _factory.CreateClient();
 
@@ -68,7 +68,7 @@ public sealed class CreateMovieEndpointContractTests : IClassFixture<SmartMovieC
         Assert.Equal(new Uri($"/api/movies/{body.Id}", UriKind.Relative), createResponse.Headers.Location);
 
         HttpResponseMessage readResponse = await client.GetAsync($"/api/movies/{body.Id}");
-        Assert.Equal(HttpStatusCode.NotFound, readResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, readResponse.StatusCode);
     }
 
     [Fact]

--- a/backend/tests/SmartMovieCatalog.Api.Tests/Movies/GetMovieByIdEndpointTests.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/Movies/GetMovieByIdEndpointTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Mvc;
+using SmartMovieCatalog.Api.Tests.TestSupport;
+using SmartMovieCatalog.Contracts.Movies;
+
+namespace SmartMovieCatalog.Api.Tests.Movies;
+
+public sealed class GetMovieByIdEndpointTests : IClassFixture<SmartMovieCatalogApiFactory>
+{
+    private readonly SmartMovieCatalogApiFactory _factory;
+
+    public GetMovieByIdEndpointTests(SmartMovieCatalogApiFactory factory)
+    {
+        _factory = factory;
+        _factory.Users.Clear();
+        _factory.Movies.Clear();
+        _factory.Genres.Clear();
+    }
+
+    [Fact]
+    public async Task GetMovieById_WithExistingMovie_ReturnsMovieDetails()
+    {
+        HttpClient client = _factory.CreateClient();
+        HttpResponseMessage createResponse = await client.PostAsJsonAsync(
+            "/api/movies",
+            CreateMovieEndpointTests.ValidRequest() with
+            {
+                ExternalId = 666,
+                Image = "/p/central.jpg"
+            });
+
+        MovieResponse? createdMovie = await createResponse.Content.ReadFromJsonAsync<MovieResponse>();
+        Assert.NotNull(createdMovie);
+
+        HttpResponseMessage response = await client.GetAsync($"/api/movies/{createdMovie.Id}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+        MovieDetailsResponse? details = await response.Content.ReadFromJsonAsync<MovieDetailsResponse>();
+        Assert.NotNull(details);
+        Assert.Equal(createdMovie.Id, details.Id);
+        Assert.Equal("Central do Brasil", details.Title);
+        Assert.Equal("BR", details.CountryCode);
+        Assert.Equal("pt-BR", details.OriginalLanguage);
+        Assert.Equal(["Drama"], details.Genres);
+        Assert.Equal(666, details.ExternalId);
+        Assert.Equal("/p/central.jpg", details.PosterUrl);
+        Assert.NotEqual(default, details.CreatedAt);
+    }
+
+    [Fact]
+    public async Task GetMovieById_WithInvalidId_ReturnsBadRequestProblemDetails()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync("/api/movies/not-a-guid");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+        ProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problemDetails);
+        Assert.Equal(400, problemDetails.Status);
+        Assert.False(string.IsNullOrWhiteSpace(problemDetails.Type));
+        Assert.False(string.IsNullOrWhiteSpace(problemDetails.Title));
+        Assert.False(string.IsNullOrWhiteSpace(problemDetails.Detail));
+        Assert.False(string.IsNullOrWhiteSpace(problemDetails.Instance));
+    }
+
+    [Fact]
+    public async Task GetMovieById_WithUnknownId_ReturnsNotFoundProblemDetails()
+    {
+        HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync($"/api/movies/{Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+        ProblemDetails? problemDetails = await response.Content.ReadFromJsonAsync<ProblemDetails>();
+        Assert.NotNull(problemDetails);
+        Assert.Equal(404, problemDetails.Status);
+        Assert.False(string.IsNullOrWhiteSpace(problemDetails.Type));
+        Assert.False(string.IsNullOrWhiteSpace(problemDetails.Title));
+        Assert.False(string.IsNullOrWhiteSpace(problemDetails.Detail));
+        Assert.False(string.IsNullOrWhiteSpace(problemDetails.Instance));
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/FakeMovieRepository.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/FakeMovieRepository.cs
@@ -21,6 +21,12 @@ public sealed class FakeMovieRepository : IMovieRepository
         return Task.CompletedTask;
     }
 
+    public Task<Movie?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        Movie? movie = _movies.SingleOrDefault(currentMovie => currentMovie.Id == id);
+        return Task.FromResult(movie);
+    }
+
     public Task<PagedResult<Movie>> ListAsync(
         string? query,
         int page,

--- a/backend/tests/SmartMovieCatalog.Application.Tests/Movies/GetMovieByIdHandlerTests.cs
+++ b/backend/tests/SmartMovieCatalog.Application.Tests/Movies/GetMovieByIdHandlerTests.cs
@@ -1,0 +1,64 @@
+using SmartMovieCatalog.Application;
+using SmartMovieCatalog.Application.Features.Movies;
+using SmartMovieCatalog.Application.Tests.TestSupport;
+using SmartMovieCatalog.Domain.Movies;
+
+namespace SmartMovieCatalog.Application.Tests.Movies;
+
+public sealed class GetMovieByIdHandlerTests
+{
+    [Fact]
+    public async Task Handle_WithExistingMovie_ReturnsMovieDetails()
+    {
+        FakeMovieRepository movies = new();
+        Genre drama = Genre.Create(GenreId.New(), "Drama", externalId: null);
+        Movie movie = CreateMovie("Central do Brasil", drama);
+        await movies.AddAsync(movie, CancellationToken.None);
+        GetMovieByIdHandler handler = new(movies);
+
+        Result<MovieDetails, GetMovieByIdFailure> result = await handler.Handle(
+            new GetMovieByIdQuery(movie.Id),
+            CancellationToken.None);
+
+        Assert.True(result.IsSuccess);
+        MovieDetails details = result.Value;
+        Assert.Equal(movie.Id, details.Id);
+        Assert.Equal("Central do Brasil", details.Title);
+        Assert.Equal("BR", details.CountryCode);
+        Assert.Equal(["Drama"], details.Genres);
+        Assert.Equal("/p/central.jpg", details.PosterUrl);
+    }
+
+    [Fact]
+    public async Task Handle_WithMissingMovie_ReturnsNotFoundFailure()
+    {
+        FakeMovieRepository movies = new();
+        GetMovieByIdHandler handler = new(movies);
+
+        Result<MovieDetails, GetMovieByIdFailure> result = await handler.Handle(
+            new GetMovieByIdQuery(Guid.NewGuid()),
+            CancellationToken.None);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(GetMovieByIdFailure.NotFound, result.Error);
+    }
+
+    private static Movie CreateMovie(string title, Genre genre)
+    {
+        return Movie.Create(
+            MovieId.New(),
+            title,
+            "Central Station",
+            1998,
+            "BR",
+            "pt-BR",
+            [genre],
+            "Walter Salles",
+            "A retired teacher and a young boy travel through Brazil.",
+            110,
+            "12",
+            666,
+            "/p/central.jpg",
+            new DateTimeOffset(2026, 5, 4, 12, 0, 0, TimeSpan.Zero));
+    }
+}

--- a/backend/tests/SmartMovieCatalog.Application.Tests/TestSupport/FakeMovieRepository.cs
+++ b/backend/tests/SmartMovieCatalog.Application.Tests/TestSupport/FakeMovieRepository.cs
@@ -16,6 +16,12 @@ public sealed class FakeMovieRepository : IMovieRepository
         return Task.CompletedTask;
     }
 
+    public Task<Movie?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        Movie? movie = _movies.SingleOrDefault(currentMovie => currentMovie.Id == id);
+        return Task.FromResult(movie);
+    }
+
     public Task<PagedResult<Movie>> ListAsync(
         string? query,
         int page,

--- a/backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs
+++ b/backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs
@@ -83,6 +83,23 @@ public sealed class EfMovieRepositoryTests
     }
 
     [Fact]
+    public async Task GetByIdAsync_WithExistingMovie_ReturnsMovieWithGenres()
+    {
+        await using SmartMovieCatalogDbContext dbContext = CreateDbContext();
+        EfMovieRepository repository = new(dbContext);
+        Genre genre = Genre.Create(GenreId.New(), "Drama", externalId: null);
+        Movie movie = CreateMovie("Central do Brasil", genre);
+        await repository.AddAsync(movie, CancellationToken.None);
+        await repository.SaveChangesAsync(CancellationToken.None);
+
+        Movie? result = await repository.GetByIdAsync(movie.Id, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal(movie.Id, result.Id);
+        Assert.Contains(result.Genres, movieGenre => movieGenre.Genre.Name == "Drama");
+    }
+
+    [Fact]
     public void Model_MapsGenreExternalIdAsUniqueAndMovieGenresAsAssociation()
     {
         using SmartMovieCatalogDbContext dbContext = CreateDbContext();

--- a/docs/API.md
+++ b/docs/API.md
@@ -10,6 +10,7 @@ Current backend endpoints include:
 - `POST /api/auth/authenticate`
 - `GET /api/auth/me`
 - `GET /api/movies`
+- `GET /api/movies/{id}`
 - `POST /api/movies`
 
 The WeatherForecast scaffold endpoint has been removed.
@@ -98,6 +99,37 @@ Returns `200 OK` with:
 
 Invalid pagination parameters return `400 Bad Request` as `ValidationProblemDetails`.
 
+### `GET /api/movies/{id}`
+
+Does not require authentication in the current movie catalog slice.
+
+Returns `200 OK` with:
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "title": "Central do Brasil",
+  "originalTitle": "Central Station",
+  "releaseYear": 1998,
+  "countryCode": "BR",
+  "originalLanguage": "pt-BR",
+  "genres": ["Drama"],
+  "director": "Walter Salles",
+  "synopsis": "A retired teacher and a young boy travel through Brazil in search of his father.",
+  "durationMinutes": 110,
+  "ageRating": "12",
+  "externalId": 666,
+  "posterUrl": "/p/example-card.jpg",
+  "createdAt": "2026-05-04T12:00:00+00:00"
+}
+```
+
+Error behavior:
+
+- Invalid `{id}` (non-GUID) returns `400 Bad Request` as `ProblemDetails` (`application/problem+json`).
+- Valid GUID that does not exist returns `404 Not Found` as `ProblemDetails` (`application/problem+json`).
+- Problem responses include `type`, `title`, `status`, `detail`, and `instance`.
+
 ### `POST /api/movies`
 
 Does not require authentication in the first movie catalog slice.
@@ -161,13 +193,12 @@ Returns `201 Created` with `Location: /api/movies/{id}` and:
 
 Invalid request shape and validation failures return `400 Bad Request` as `ValidationProblemDetails`.
 
-`GET /api/movies/{id}` is not implemented in this slice; the `Location` header reserves the future resource URI.
-
 Genre names in movie requests and responses remain public strings. The backend stores genres as reusable catalog records internally, but `POST /api/movies` does not accept or return genre IDs or TMDB genre IDs.
 
 ## Frontend Consumption
 - The Angular login module calls `POST /api/auth/authenticate` with `email` and `password`.
 - On successful authentication, it calls `GET /api/auth/me` using the returned bearer token.
+- The Angular movie details page calls `GET /api/movies/{id}` through a typed movies API service.
 - The frontend relies on same-origin `/api` paths. During local `ng serve`, `frontend/src/proxy.conf.js` forwards `/api` to the backend.
 - The frontend maps `400 ValidationProblemDetails` to field-level validation and keeps `401 ProblemDetails` generic to avoid account enumeration.
 - No Angular movie creation flow exists yet.

--- a/docs/FRONTEND.md
+++ b/docs/FRONTEND.md
@@ -13,6 +13,7 @@ Primary references:
 ## Routing
 - `/` displays the authentication login page.
 - `/catalog` displays the public V1 catalog page.
+- `/movies/:id` displays movie details for a single movie.
 - `/catalog` reads `query`, `page`, and `pageSize` from URL query parameters.
 - Catalog `pageSize` defaults to `12` when omitted or invalid. A valid URL `pageSize` in the range `1..100` is honored, but V1 does not show a page-size selector.
 - Catalog item links target the movie details route pattern `/movies/{id}` established by the movie details feature.
@@ -38,9 +39,11 @@ Do not introduce another design system, component library, custom palette, or vi
 
 ## Movie Catalog UI
 - The catalog page lives under `frontend/src/app/catalog/catalog-page`.
+- The movie details page lives under `frontend/src/app/movies/movie-details-page`.
 - Movie catalog HTTP calls are isolated in `frontend/src/app/movies/movies-api.ts`.
 - Movie catalog contracts are mirrored as TypeScript interfaces in `frontend/src/app/movies/movie.models.ts` and must stay aligned with the movie listing/search API contracts.
 - Catalog components must not call `HttpClient` directly.
+- Movie details components must not call `HttpClient` directly and must use `MoviesApi.getMovieById`.
 - The V1 catalog route is public and does not require route guards or an authenticated frontend session.
 - Search is basic title search through `GET /api/movies?query=...`; do not show semantic search, vector search, RAG, CLIP, recommendation, or AI ranking terminology for this feature.
 

--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -4,7 +4,8 @@ import { of } from 'rxjs';
 import { App } from './app';
 import { LoginPage } from './auth/login-page/login-page';
 import { CatalogPage } from './catalog/catalog-page/catalog-page';
-import { PagedMovieSummaryResponse } from './movies/movie.models';
+import { MovieDetails, PagedMovieSummaryResponse } from './movies/movie.models';
+import { MovieDetailsPage } from './movies/movie-details-page/movie-details-page';
 import { MoviesApi } from './movies/movies-api';
 
 describe('App', () => {
@@ -22,18 +23,37 @@ describe('App', () => {
     hasNextPage: false
   };
 
+  const detailsResponse: MovieDetails = {
+    id: 'movie-1',
+    title: 'Central do Brasil',
+    originalTitle: 'Central Station',
+    releaseYear: 1998,
+    countryCode: 'BR',
+    originalLanguage: 'pt-BR',
+    genres: ['Drama'],
+    director: 'Walter Salles',
+    synopsis: 'A retired teacher and a young boy travel through Brazil in search of his father.',
+    durationMinutes: 110,
+    ageRating: '12',
+    externalId: 666,
+    posterUrl: '/p/central.jpg',
+    createdAt: '2026-05-04T12:00:00Z'
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
       providers: [
         provideRouter([
           { path: '', component: LoginPage },
-          { path: 'catalog', component: CatalogPage }
+          { path: 'catalog', component: CatalogPage },
+          { path: 'movies/:id', component: MovieDetailsPage }
         ]),
         {
           provide: MoviesApi,
           useValue: {
-            listMovies: vi.fn(() => of(emptyResponse))
+            listMovies: vi.fn(() => of(emptyResponse)),
+            getMovieById: vi.fn(() => of(detailsResponse))
           }
         }
       ]
@@ -69,5 +89,18 @@ describe('App', () => {
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('app-catalog-page')).toBeTruthy();
     expect(compiled.textContent).toContain('Catalog');
+  });
+
+  it('should render the movie details route', async () => {
+    fixture.detectChanges();
+
+    await router.navigateByUrl('/movies/movie-1');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('app-movie-details-page')).toBeTruthy();
+    expect(compiled.textContent).toContain('Central do Brasil');
   });
 });

--- a/frontend/src/app/movies/movie-details-page/movie-details-page.css
+++ b/frontend/src/app/movies/movie-details-page/movie-details-page.css
@@ -1,0 +1,303 @@
+:host {
+  display: block;
+}
+
+.movie-details-page {
+  min-height: 100vh;
+  color: #e4e1ed;
+  background: #111;
+}
+
+.state-panel {
+  display: grid;
+  justify-items: center;
+  gap: .75rem;
+  margin: 6rem auto 2rem;
+  padding: 2rem 1.5rem;
+  background: #17181dc7;
+}
+
+.hero-info h1,
+.hero-synopsis h2 {
+  color: #f8fafc;
+}
+
+.hero-synopsis p,
+.metric-row span {
+  color: #cbd5e1;
+}
+
+.hero-synopsis .material-symbols-outlined,
+.insight-panel header .material-symbols-outlined,
+.insight-panel h2 {
+  color: #c0c1ff;
+}
+
+.hero-shell {
+  position: relative;
+  min-height: min(660px, calc(100vh - 1rem));
+  overflow: hidden;
+  background: #111;
+}
+
+.hero-background,
+.hero-overlay {
+  position: absolute;
+  inset: 0;
+}
+
+.hero-background {
+  background-size: cover;
+  opacity: .34;
+}
+
+.hero-overlay {
+  background: linear-gradient(0deg, #111 0%, #111111db 46%, #1111116b 100%);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: min(1280px, 100%);
+  min-height: inherit;
+  margin: 0 auto;
+  padding: 5.25rem 1.5rem 3.5rem;
+}
+
+.hero-poster {
+  display: none;
+}
+
+.hero-info h1 {
+  margin: 0;
+  font-size: clamp(2.6rem, 7vw, 4.75rem);
+  font-weight: 800;
+}
+
+.details-subtitle {
+  margin: .8rem 0 0;
+  color: #cbd5e1;
+}
+
+.hero-actions,
+.genre-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .65rem;
+}
+
+.genre-tags span {
+  background: #6366f124;
+  color: #e0e7ff;
+  padding: .38rem .7rem;
+  font-size: .75rem;
+}
+
+.hero-actions {
+  margin-top: 2rem;
+  width: min(48rem, 100%);
+  align-items: center;
+}
+
+.hero-actions a {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  border-radius: .75rem;
+  padding: 0 1.25rem;
+  color: #f8fafc;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.hero-actions .info-badge:first-of-type {
+  margin-left:auto;
+}
+
+.primary-action {
+  background: #c0c1ff;
+  color: #1000a9 !important;
+}
+
+.hero-synopsis {
+  border: 1px solid #ffffff14;
+  background: #17181db8;
+  backdrop-filter: blur(12px);
+}
+
+.details-layout {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  width: min(1280px, 100%);
+  margin: -1.5rem auto 0;
+  padding: 0 1.5rem 5rem;
+  gap: 2rem;
+}
+
+.details-main,
+.details-side {
+  display: grid;
+  align-content: start;
+  gap: 1.2rem;
+  min-width: 0;
+}
+
+.hero-synopsis,
+.insight-panel,
+.meta-grid div {
+  border-radius: .75rem;
+}
+
+.hero-synopsis {
+  max-width: 48rem;
+  margin-top: 1.25rem;
+  padding: 1.15rem 1.25rem;
+}
+
+.hero-synopsis h2,
+.insight-panel header {
+  display: flex;
+  align-items: center;
+  gap: .55rem;
+}
+
+.hero-synopsis h2,
+.hero-synopsis p {
+  margin: 0;
+}
+
+.hero-synopsis h2 {
+  margin-bottom: .65rem;
+}
+
+.meta-grid {
+  display: grid;
+  gap: .9rem;
+  margin: 0;
+}
+
+.meta-grid div {
+  border: 1px solid #2a2b33;
+  background: #1f1f27;
+  padding: 1rem;
+}
+
+.meta-grid dt,
+.insight-label {
+  margin: 0 0 .5rem;
+  color: #8b8f9c;
+  font-size: .75rem;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.meta-grid dd {
+  margin: 0;
+  color: #f8fafc;
+}
+
+.insight-panel {
+  border: 1px solid #6366f159;
+  background: #1e1b754d;
+  padding: 1.4rem;
+}
+
+.insight-panel header {
+  margin-bottom: 1.2rem;
+}
+
+.insight-panel h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.insight-block {
+  display: grid;
+  gap: .7rem;
+  margin-top: 1rem;
+}
+
+.metric-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.progress-track {
+  height: .45rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: #ffffff0f;
+}
+
+.progress-track div {
+  height: 100%;
+  border-radius: inherit;
+  background: #c0c1ff;
+}
+
+.quick-info {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .65rem;
+}
+
+.info-badge {
+  border: 1px solid #ffffff14;
+  border-radius: 999px;
+  background: #17181db8;
+  color: #c0c1ff;
+  padding: .38rem .7rem;
+  font-size: .75rem;
+  text-transform: uppercase;
+}
+
+.info-badge-country { border-color: #22c55e40; background: #22c55e24; color: #22c55e; }
+
+@media (min-width: 760px) {
+  .meta-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 900px) {
+  .hero-content {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: 3rem;
+  }
+
+  .hero-poster {
+    display: block;
+    width: 18rem;
+    flex: 0 0 18rem;
+    overflow: hidden;
+    border: 1px solid #ffffff1f;
+    border-radius: .75rem;
+    background: #17181d;
+    box-shadow: 0 25px 50px -12px #0000008c;
+  }
+
+  .hero-poster img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+  }
+
+  .details-layout {
+    grid-template-columns: minmax(0, 8fr) minmax(19rem, 4fr);
+  }
+}
+
+@media (max-width: 640px) {
+  .hero-content { padding: 5rem 1rem 2.5rem; }
+  .hero-actions a { width: 100%; justify-content: center; }
+  .hero-actions .info-badge:first-of-type { margin-left:0; }
+  .details-layout { margin-top: -1rem; padding-inline: 1rem; }
+}

--- a/frontend/src/app/movies/movie-details-page/movie-details-page.html
+++ b/frontend/src/app/movies/movie-details-page/movie-details-page.html
@@ -1,0 +1,121 @@
+<section class="movie-details-page" aria-labelledby="movie-details-title">
+  <div class="state-panel" *ngIf="loadState() === 'loading'" role="status">
+    <span class="material-symbols-outlined" aria-hidden="true">hourglass_top</span>
+    <p>Loading movie details</p>
+  </div>
+
+  <div class="state-panel" *ngIf="loadState() === 'notFound'" role="status">
+    <span class="material-symbols-outlined" aria-hidden="true">movie</span>
+    <h1 id="movie-details-title">Movie not found</h1>
+    <p>We could not find this movie in the catalog.</p>
+    <a routerLink="/catalog">Back to catalog</a>
+  </div>
+
+  <div class="state-panel state-panel-error" *ngIf="loadState() === 'error'" role="alert">
+    <span class="material-symbols-outlined" aria-hidden="true">error</span>
+    <h1 id="movie-details-title">Details unavailable</h1>
+    <p>Try again in a moment.</p>
+    <a routerLink="/catalog">Back to catalog</a>
+  </div>
+
+  <article class="details-article" *ngIf="loadState() === 'success' && movie() as details">
+    <section class="hero-shell">
+      <div
+        class="hero-background"
+        [style.background-image]="heroBackgroundStyle(details.posterUrl)"
+        aria-hidden="true"></div>
+      <div class="hero-overlay" aria-hidden="true"></div>
+
+      <div class="hero-content">
+        <div class="hero-poster">
+          <img
+            *ngIf="details.posterUrl; else noPoster"
+            [src]="posterImageUrl(details.posterUrl)"
+            [alt]="details.title + ' poster'">
+          <ng-template #noPoster>
+            <div class="poster-placeholder" aria-hidden="true">
+              <span class="material-symbols-outlined">movie</span>
+            </div>
+          </ng-template>
+        </div>
+
+        <div class="hero-info">
+          <h1 id="movie-details-title">{{ details.title }}</h1>
+          <p class="details-subtitle" *ngIf="details.originalTitle && details.originalTitle !== details.title">
+            {{ details.originalTitle }}
+          </p>
+
+          <div class="hero-actions">
+            <a class="primary-action" routerLink="/catalog">
+              <span class="material-symbols-outlined" aria-hidden="true">arrow_back</span>
+              <span>Back to catalog</span>
+            </a>
+            <span class="info-badge">Lancamento {{ details.releaseYear }}</span>
+            <span class="info-badge info-badge-country">{{ details.countryCode }}</span>
+          </div>
+
+          <section class="hero-synopsis">
+            <h2>
+              <span class="material-symbols-outlined" aria-hidden="true">description</span>
+              <span>Synopsis</span>
+            </h2>
+            <p>{{ valueOrFallback(details.synopsis) }}</p>
+          </section>
+        </div>
+      </div>
+    </section>
+
+    <section class="details-layout">
+      <div class="details-main">
+        <dl class="meta-grid">
+          <div>
+            <dt>Director</dt>
+            <dd>{{ valueOrFallback(details.director) }}</dd>
+          </div>
+          <div>
+            <dt>Duration</dt>
+            <dd>{{ details.durationMinutes ? details.durationMinutes + ' min' : 'Not informed' }}</dd>
+          </div>
+          <div>
+            <dt>Genres</dt>
+            <dd>{{ genresLabel() }}</dd>
+          </div>
+          <div>
+            <dt>Age Rating</dt>
+            <dd>{{ valueOrFallback(details.ageRating) }}</dd>
+          </div>
+        </dl>
+      </div>
+
+      <aside class="details-side">
+        <section class="insight-panel">
+          <header>
+            <span class="material-symbols-outlined" aria-hidden="true">analytics</span>
+            <h2>Catalog Insight</h2>
+          </header>
+
+          <div class="insight-block">
+            <span class="insight-label">Genres</span>
+            <div class="genre-tags" *ngIf="details.genres.length > 0; else noGenres">
+              <span *ngFor="let genre of details.genres">{{ genre }}</span>
+            </div>
+            <ng-template #noGenres>
+              <p class="muted-line">Not informed</p>
+            </ng-template>
+          </div>
+
+          <div class="insight-block">
+            <div class="metric-row">
+              <span>Metadata completeness</span>
+              <strong>{{ metadataCompleteness() }}%</strong>
+            </div>
+            <div class="progress-track" aria-hidden="true">
+              <div [style.width]="progressWidth(metadataCompleteness())"></div>
+            </div>
+          </div>
+        </section>
+
+      </aside>
+    </section>
+  </article>
+</section>

--- a/frontend/src/app/movies/movie-details-page/movie-details-page.spec.ts
+++ b/frontend/src/app/movies/movie-details-page/movie-details-page.spec.ts
@@ -1,0 +1,106 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, ParamMap, provideRouter } from '@angular/router';
+import { BehaviorSubject, NEVER, of, throwError } from 'rxjs';
+import { MovieDetails } from '../movie.models';
+import { MoviesApi } from '../movies-api';
+import { MovieDetailsPage } from './movie-details-page';
+
+describe('MovieDetailsPage', () => {
+  let fixture: ComponentFixture<MovieDetailsPage>;
+  let paramMap: BehaviorSubject<ParamMap>;
+  let moviesApi: {
+    getMovieById: ReturnType<typeof vi.fn<(id: string) => ReturnType<MoviesApi['getMovieById']>>>;
+  };
+
+  const details: MovieDetails = {
+    id: 'movie-1',
+    title: 'Central do Brasil',
+    originalTitle: 'Central Station',
+    releaseYear: 1998,
+    countryCode: 'BR',
+    originalLanguage: 'pt-BR',
+    genres: ['Drama'],
+    director: 'Walter Salles',
+    synopsis: 'A retired teacher and a young boy travel through Brazil in search of his father.',
+    durationMinutes: 110,
+    ageRating: '12',
+    externalId: 666,
+    posterUrl: '/p/central.jpg',
+    createdAt: '2026-05-04T12:00:00Z'
+  };
+
+  beforeEach(async () => {
+    paramMap = new BehaviorSubject<ParamMap>(convertToParamMap({ id: 'movie-1' }));
+    moviesApi = {
+      getMovieById: vi.fn(() => of(details))
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [MovieDetailsPage],
+      providers: [
+        provideRouter([]),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: paramMap.asObservable()
+          }
+        },
+        { provide: MoviesApi, useValue: moviesApi }
+      ]
+    }).compileComponents();
+  });
+
+  function createComponent(): void {
+    fixture = TestBed.createComponent(MovieDetailsPage);
+    fixture.detectChanges();
+  }
+
+  it('should request details by route movie id and render success state', () => {
+    createComponent();
+
+    expect(moviesApi.getMovieById).toHaveBeenCalledWith('movie-1');
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Central do Brasil');
+    expect(compiled.textContent).toContain('Walter Salles');
+    expect(compiled.textContent).toContain('A retired teacher and a young boy');
+  });
+
+  it('should render loading state while waiting for response', () => {
+    moviesApi.getMovieById.mockReturnValue(NEVER);
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Loading movie details');
+  });
+
+  it('should render not-found state for 404 responses', () => {
+    moviesApi.getMovieById.mockReturnValue(throwError(() => new HttpErrorResponse({
+      status: 404,
+      statusText: 'Not Found'
+    })));
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Movie not found');
+  });
+
+  it('should render generic error state for non-404 failures', () => {
+    moviesApi.getMovieById.mockReturnValue(throwError(() => new HttpErrorResponse({
+      status: 500,
+      statusText: 'Server Error'
+    })));
+    createComponent();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Details unavailable');
+    expect(compiled.textContent).toContain('Try again in a moment.');
+  });
+
+  it('should convert poster path to TMDB URL', () => {
+    createComponent();
+
+    const image = fixture.nativeElement.querySelector('.hero-poster img') as HTMLImageElement;
+    expect(image.src).toBe('https://image.tmdb.org/t/p/w500/p/central.jpg');
+  });
+});

--- a/frontend/src/app/movies/movie-details-page/movie-details-page.ts
+++ b/frontend/src/app/movies/movie-details-page/movie-details-page.ts
@@ -1,0 +1,121 @@
+import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { catchError, distinctUntilChanged, map, of, switchMap, tap } from 'rxjs';
+import { MovieDetails, MovieDetailsLoadState } from '../movie.models';
+import { MoviesApi } from '../movies-api';
+
+interface MovieDetailsLoadResult {
+  state: MovieDetailsLoadState;
+  movie: MovieDetails | null;
+}
+
+const tmdbImageSize = 'w500';
+const tmdbImageBaseUrl = `https://image.tmdb.org/t/p/${tmdbImageSize}`;
+
+@Component({
+  selector: 'app-movie-details-page',
+  imports: [CommonModule, RouterLink],
+  templateUrl: './movie-details-page.html',
+  styleUrl: './movie-details-page.css',
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MovieDetailsPage implements OnInit {
+  private readonly route = inject(ActivatedRoute);
+  private readonly moviesApi = inject(MoviesApi);
+  private readonly destroyRef = inject(DestroyRef);
+
+  protected readonly loadState = signal<MovieDetailsLoadState>('loading');
+  protected readonly movie = signal<MovieDetails | null>(null);
+
+  protected readonly genresLabel = computed(() => {
+    const genres = this.movie()?.genres;
+    return genres && genres.length > 0 ? genres.join(' / ') : 'Not informed';
+  });
+
+  protected readonly metadataCompleteness = computed(() => {
+    const details = this.movie();
+    if (!details) {
+      return 0;
+    }
+
+    const values = [
+      details.originalTitle,
+      details.director,
+      details.synopsis,
+      details.durationMinutes,
+      details.ageRating,
+      details.externalId,
+      details.posterUrl,
+      details.genres.length > 0 ? details.genres : null
+    ];
+
+    const availableValues = values.filter(value => value !== null && value !== undefined && value !== '').length;
+    return Math.round((availableValues / values.length) * 100);
+  });
+
+  public ngOnInit(): void {
+    this.route.paramMap.pipe(
+      map(params => params.get('id')?.trim() ?? ''),
+      distinctUntilChanged(),
+      tap(() => this.prepareForLoad()),
+      switchMap(id => {
+        if (!id) {
+          return of<MovieDetailsLoadResult>({ state: 'notFound', movie: null });
+        }
+
+        return this.moviesApi.getMovieById(id).pipe(
+          map(movie => ({ state: 'success' as const, movie })),
+          catchError((error: unknown) => {
+            if (error instanceof HttpErrorResponse && error.status === 404) {
+              return of<MovieDetailsLoadResult>({ state: 'notFound', movie: null });
+            }
+
+            return of<MovieDetailsLoadResult>({ state: 'error', movie: null });
+          })
+        );
+      }),
+      takeUntilDestroyed(this.destroyRef)
+    ).subscribe(result => this.applyResult(result));
+  }
+
+  protected posterImageUrl(posterPath: string): string {
+    if (posterPath.startsWith('http://') || posterPath.startsWith('https://')) {
+      return posterPath;
+    }
+
+    return `${tmdbImageBaseUrl}${posterPath.startsWith('/') ? posterPath : `/${posterPath}`}`;
+  }
+
+  protected heroBackgroundStyle(posterPath: string | null): string | null {
+    if (!posterPath) {
+      return null;
+    }
+
+    return `url('${this.posterImageUrl(posterPath)}')`;
+  }
+
+  protected valueOrFallback(value: string | number | null | undefined): string | number {
+    if (value === null || value === undefined || value === '') {
+      return 'Not informed';
+    }
+
+    return value;
+  }
+
+  protected progressWidth(value: number): string {
+    return `${Math.min(Math.max(value, 0), 100)}%`;
+  }
+
+  private prepareForLoad(): void {
+    this.loadState.set('loading');
+    this.movie.set(null);
+  }
+
+  private applyResult(result: MovieDetailsLoadResult): void {
+    this.loadState.set(result.state);
+    this.movie.set(result.movie);
+  }
+}

--- a/frontend/src/app/movies/movie.models.ts
+++ b/frontend/src/app/movies/movie.models.ts
@@ -25,6 +25,23 @@ export interface MovieListQuery {
   pageSize: number;
 }
 
+export interface MovieDetails {
+  id: string;
+  title: string;
+  originalTitle: string | null;
+  releaseYear: number;
+  countryCode: string;
+  originalLanguage: string;
+  genres: string[];
+  director: string | null;
+  synopsis: string | null;
+  durationMinutes: number | null;
+  ageRating: string | null;
+  externalId: number | null;
+  posterUrl: string | null;
+  createdAt: string;
+}
+
 export interface CatalogViewState {
   query: string;
   page: number;
@@ -32,3 +49,5 @@ export interface CatalogViewState {
 }
 
 export type CatalogLoadState = 'loading' | 'success' | 'emptyCatalog' | 'noResults' | 'error';
+
+export type MovieDetailsLoadState = 'loading' | 'success' | 'notFound' | 'error';

--- a/frontend/src/app/movies/movies-api.spec.ts
+++ b/frontend/src/app/movies/movies-api.spec.ts
@@ -1,7 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { PagedMovieSummaryResponse } from './movie.models';
+import { MovieDetails, PagedMovieSummaryResponse } from './movie.models';
 import { MoviesApi } from './movies-api';
 
 describe('MoviesApi', () => {
@@ -27,6 +27,23 @@ describe('MoviesApi', () => {
     totalPages: 4,
     hasPreviousPage: true,
     hasNextPage: true
+  };
+
+  const detailsResponse: MovieDetails = {
+    id: 'movie-1',
+    title: 'Central do Brasil',
+    originalTitle: 'Central Station',
+    releaseYear: 1998,
+    countryCode: 'BR',
+    originalLanguage: 'pt-BR',
+    genres: ['Drama'],
+    director: 'Walter Salles',
+    synopsis: 'A retired teacher and a young boy travel through Brazil in search of his father.',
+    durationMinutes: 110,
+    ageRating: '12',
+    externalId: 666,
+    posterUrl: '/p/central.jpg',
+    createdAt: '2026-05-04T12:00:00Z'
   };
 
   beforeEach(() => {
@@ -101,5 +118,15 @@ describe('MoviesApi', () => {
     );
 
     request.flush(response);
+  });
+
+  it('should request movie details by id', () => {
+    moviesApi.getMovieById('movie-1').subscribe(result => {
+      expect(result).toEqual(detailsResponse);
+    });
+
+    const request = httpTestingController.expectOne('/api/movies/movie-1');
+    expect(request.request.method).toBe('GET');
+    request.flush(detailsResponse);
   });
 });

--- a/frontend/src/app/movies/movies-api.ts
+++ b/frontend/src/app/movies/movies-api.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { MovieListQuery, PagedMovieSummaryResponse } from './movie.models';
+import { MovieDetails, MovieListQuery, PagedMovieSummaryResponse } from './movie.models';
 
 @Injectable({
   providedIn: 'root'
@@ -20,5 +20,9 @@ export class MoviesApi {
     }
 
     return this.http.get<PagedMovieSummaryResponse>('/api/movies', { params });
+  }
+
+  public getMovieById(id: string): Observable<MovieDetails> {
+    return this.http.get<MovieDetails>(`/api/movies/${id}`);
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,6 +5,7 @@ import { provideRouter } from '@angular/router';
 import { App } from './app/app';
 import { LoginPage } from './app/auth/login-page/login-page';
 import { CatalogPage } from './app/catalog/catalog-page/catalog-page';
+import { MovieDetailsPage } from './app/movies/movie-details-page/movie-details-page';
 
 bootstrapApplication(App, {
   providers: [
@@ -12,7 +13,8 @@ bootstrapApplication(App, {
     provideHttpClient(),
     provideRouter([
       { path: '', component: LoginPage },
-      { path: 'catalog', component: CatalogPage }
+      { path: 'catalog', component: CatalogPage },
+      { path: 'movies/:id', component: MovieDetailsPage }
     ]),
   ]
 })

--- a/specs/013-view-movie-details/.spec-context.json
+++ b/specs/013-view-movie-details/.spec-context.json
@@ -1,0 +1,50 @@
+{
+  "workflow": "speckit",
+  "specName": "013-view-movie-details",
+  "branch": "013-view-movie-details",
+  "selectedAt": "2026-05-09T00:34:54.614Z",
+  "currentStep": "plan",
+  "status": "planning",
+  "stepHistory": {
+    "plan": {
+      "startedAt": "2026-05-09T00:57:19.273Z",
+      "completedAt": null
+    },
+    "tasks": {
+      "startedAt": "2026-05-09T00:35:03.333Z",
+      "completedAt": null
+    }
+  },
+  "transitions": [
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "plan",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-09T00:35:03.331Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-09T00:35:03.333Z"
+    },
+    {
+      "step": "plan",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-09T00:57:19.273Z"
+    }
+  ]
+}

--- a/specs/013-view-movie-details/contracts/get-movie-by-id.md
+++ b/specs/013-view-movie-details/contracts/get-movie-by-id.md
@@ -1,0 +1,38 @@
+# Contract: GET /api/movies/{id}
+
+## Endpoint
+- Method: `GET`
+- Route: `/api/movies/{id}`
+- Auth: not required
+
+## Path parameters
+- `id` (required): movie identifier as GUID string.
+
+## 200 OK (`application/json`)
+
+```json
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "title": "Central do Brasil",
+  "originalTitle": "Central Station",
+  "releaseYear": 1998,
+  "countryCode": "BR",
+  "originalLanguage": "pt-BR",
+  "genres": ["Drama"],
+  "director": "Walter Salles",
+  "synopsis": "A retired teacher and a young boy travel through Brazil in search of his father.",
+  "durationMinutes": 110,
+  "ageRating": "12",
+  "externalId": 666,
+  "posterUrl": "/p/example-card.jpg",
+  "createdAt": "2026-05-04T12:00:00+00:00"
+}
+```
+
+## 400 Bad Request (`application/problem+json`)
+- Trigger: `{id}` is not a valid GUID.
+- Fields: `type`, `title`, `status`, `detail`, `instance`.
+
+## 404 Not Found (`application/problem+json`)
+- Trigger: valid GUID format with no matching movie.
+- Fields: `type`, `title`, `status`, `detail`, `instance`.

--- a/specs/013-view-movie-details/data-model.md
+++ b/specs/013-view-movie-details/data-model.md
@@ -1,0 +1,30 @@
+# Data Model: View Movie Details
+
+## MovieDetails (read projection)
+
+Purpose: response model for `GET /api/movies/{id}` using existing movie metadata.
+
+### Fields
+- `id` (`string`, GUID serialized)
+- `title` (`string`, required)
+- `originalTitle` (`string | null`)
+- `releaseYear` (`number`, required)
+- `countryCode` (`string`, required, 2-letter uppercase)
+- `originalLanguage` (`string`, required)
+- `genres` (`string[]`, required, can be empty)
+- `director` (`string | null`)
+- `synopsis` (`string | null`)
+- `durationMinutes` (`number | null`)
+- `ageRating` (`string | null`)
+- `externalId` (`number | null`, positive when present)
+- `posterUrl` (`string | null`, relative path currently stored by domain)
+- `createdAt` (`string`, ISO-8601 timestamp)
+
+### Validation and constraints
+- Invalid route `id` format is rejected at API boundary with `400 application/problem+json`.
+- Valid GUID with no matching movie returns `404 application/problem+json`.
+- No new persisted fields are introduced (`cast` and `updatedAt` remain out of scope).
+
+### Relationships
+- Backed by existing `Movie` aggregate and related `MovieGenre -> Genre` associations.
+- Genres are projected as public string names only.

--- a/specs/013-view-movie-details/plan.md
+++ b/specs/013-view-movie-details/plan.md
@@ -1,0 +1,169 @@
+# Implementation Plan
+
+## Overview
+
+Implement issue #13 by adding a backend movie-details read endpoint (`GET /api/movies/{id}`), a dedicated details response contract, a typed frontend details API service/model, and a `/movies/{id}` details page with loading/not-found/error states.
+
+This plan keeps scope constrained to currently supported movie metadata and explicitly excludes new persisted fields such as `cast` and `updatedAt`.
+
+## Technical Context
+
+- Language/Version:
+  - Backend: C# / ASP.NET Core 10
+  - Frontend: Angular 21 / TypeScript 5.9
+- Frameworks/Libraries:
+  - Backend: Minimal APIs, Wolverine mediator dispatch, EF Core/PostgreSQL in Infrastructure
+  - Frontend: Angular router/forms/http, RxJS, local CSS design system
+- Architecture:
+  - Clean Architecture backend (`Api -> Application -> Domain`, `Infrastructure -> Application/Domain`)
+  - Typed API services on frontend; components do not call `HttpClient` directly
+- Persistence:
+  - Existing movie and genre persistence via EF Core mappings/repositories
+- Deployment model:
+  - ASP.NET Core SPA integration with Angular
+- Testing:
+  - Backend xUnit test projects (Api/Application/Domain/Infrastructure)
+  - Frontend Vitest (`npm test -- --watch=false`)
+
+## Constitution Check
+
+- Architecture fidelity: pass. Plan follows existing Minimal API + Application handler + repository pattern and Angular typed-service pattern.
+- Boundary adherence: pass. Backend and frontend changes remain in their owned directories.
+- Contract synchronization: pass with required cross-boundary updates (Contracts + frontend models/services).
+- Security hygiene: pass. No secrets, no new trust boundaries, and explicit not-found/error response shaping.
+- Scope control: pass. Clarifications resolved with no domain expansion.
+
+No unjustified constitution violations identified.
+
+## Technical Approach
+
+1. Backend contracts:
+   - Add a dedicated movie details response DTO in `SmartMovieCatalog.Contracts`.
+2. Application layer:
+   - Add query + handler for "get movie by id" use case and map to details model.
+   - Add failure model for missing movie and map to API `404 ProblemDetails`.
+3. Persistence/repository:
+   - Extend movie repository abstraction with lookup by ID including related genres.
+   - Implement lookup in EF repository.
+4. API layer:
+   - Add `GET /api/movies/{id}` endpoint slice under `Features/Movies`.
+   - Validate route ID shape and return:
+     - `200` for success
+     - `404` problem response for missing movie
+5. Frontend data access:
+   - Add details models and typed API service method (`getMovieById(id)`).
+6. Frontend routing/page:
+   - Register `/movies/:id` route.
+   - Create details page component (loading/not-found/error/success states).
+7. Navigation alignment:
+   - Reuse existing links from catalog/list; verify route resolves.
+8. Tests:
+   - Backend endpoint + handler + repository tests.
+   - Frontend API service + component/route behavior tests.
+
+## Affected Areas
+
+- Backend:
+  - `backend/src/SmartMovieCatalog.Contracts/Movies/`
+  - `backend/src/SmartMovieCatalog.Application/Features/Movies/`
+  - `backend/src/SmartMovieCatalog.Application/Abstractions/Persistence/`
+  - `backend/src/SmartMovieCatalog.Infrastructure/Persistence/`
+  - `backend/src/SmartMovieCatalog.Api/Features/Movies/`
+- Frontend:
+  - `frontend/src/main.ts`
+  - `frontend/src/app/movies/`
+  - `frontend/src/app/` (new details feature folder)
+- Tests:
+  - `backend/tests/...`
+  - `frontend/src/app/...*.spec.ts`
+- Documentation:
+  - `docs/API.md`
+  - `docs/FRONTEND.md` (if routing/API usage descriptions change)
+
+## Data Model Changes
+
+- No mandatory domain entity expansion is planned by default.
+- The details response will project existing movie metadata:
+  - `id`, `title`, `originalTitle`, `releaseYear`, `countryCode`, `originalLanguage`,
+    `genres`, `director`, `synopsis`, `durationMinutes`, `ageRating`, `posterUrl`/`image`, `createdAt`.
+- `cast` and `updatedAt` are explicitly out of scope and will not be added in this feature.
+
+## API Changes
+
+- Add:
+  - `GET /api/movies/{id}`
+- Responses:
+  - `200 application/json` with details DTO
+  - `404 application/problem+json` for missing movie
+- Keep existing list/create endpoints unchanged.
+
+## Frontend Changes
+
+- Add details route: `/movies/:id`.
+- Add details page UI aligned with `frontend/DESIGN.md`.
+- Add typed details API method in existing movie API service boundary.
+- Render:
+  - loading state while fetching
+  - not-found state for 404
+  - generic error state for other failures
+  - details metadata on success
+
+## Backend Changes
+
+- Add details query + handler in Application.
+- Add repository lookup abstraction + EF implementation.
+- Add Minimal API endpoint in Api layer.
+- Add ProblemDetails mapping for missing movie.
+
+## Testing Strategy
+
+- Backend:
+  - API tests for `GET /api/movies/{id}` success + 404 + response shape.
+  - Application tests for handler success/failure mapping.
+  - Infrastructure tests for repository lookup behavior.
+- Frontend:
+  - API service tests for details GET call and response mapping.
+  - Details page tests for loading/not-found/error/success states.
+  - Route test for `/movies/:id`.
+- Verification commands:
+  - `dotnet build SmartMovieCatalog.slnx`
+  - `dotnet test SmartMovieCatalog.slnx --no-build`
+  - `npm test -- --watch=false` (from `frontend`)
+  - `npm run build` (from `frontend`)
+
+## Deployment Impact
+
+- No infrastructure/deployment topology changes expected.
+- No new external services or secrets.
+- API surface expands with one read endpoint.
+
+## Security Considerations
+
+- Validate and parse route ID safely.
+- Return generic, non-sensitive problem details for missing resources.
+- Do not leak persistence internals or stack traces.
+- Treat route/query/API data as untrusted on frontend rendering paths.
+
+## Observability / Logging
+
+- No new logging stack required.
+- Reuse existing ASP.NET request/response diagnostics.
+- Optional: add lightweight endpoint-level log context if current conventions allow.
+
+## Risks
+
+- Scope-growth risk is mitigated by explicit exclusion of `cast` and `updatedAt`.
+- Contract drift risk between backend DTO and frontend model.
+- UX consistency risk if details route exists but list/card surfaces diverge in navigation behavior.
+
+## Open Questions
+
+- No open functional questions remain for issue #13.
+
+## Rollout Plan
+
+1. Implement backend details endpoint with tests.
+2. Implement frontend details route/page with tests.
+3. Synchronize docs (`docs/API.md`, `docs/FRONTEND.md`).
+4. Run backend and frontend verification commands.
+5. Submit for review as a single scoped feature branch.

--- a/specs/013-view-movie-details/quickstart.md
+++ b/specs/013-view-movie-details/quickstart.md
@@ -1,0 +1,37 @@
+# Quickstart: View Movie Details
+
+## 1) Backend verification
+
+```bash
+dotnet build SmartMovieCatalog.slnx
+dotnet test SmartMovieCatalog.slnx --no-build
+```
+
+## 2) Frontend verification
+
+```bash
+cd frontend
+npm test -- --watch=false
+npm run build
+```
+
+## 3) Manual API checks
+
+### Existing movie
+1. Create a movie with `POST /api/movies`.
+2. Call `GET /api/movies/{id}` with returned id.
+3. Expect `200 application/json` with full details payload.
+
+### Invalid id format
+1. Call `GET /api/movies/not-a-guid`.
+2. Expect `400 application/problem+json`.
+
+### Missing movie
+1. Call `GET /api/movies/{guid}` with unknown GUID.
+2. Expect `404 application/problem+json`.
+
+## 4) Manual frontend checks
+1. Open `/catalog`.
+2. Open details from available movie cards/lists.
+3. Validate `/movies/{id}` renders metadata.
+4. Validate loading, not-found, and error states.

--- a/specs/013-view-movie-details/research.md
+++ b/specs/013-view-movie-details/research.md
@@ -1,0 +1,29 @@
+# Research: View Movie Details
+
+## Decision 1: Scope of metadata
+- **Decision**: Keep the details response limited to metadata already supported by current domain/API.
+- **Rationale**: Avoids schema and domain expansion in issue #13 and keeps implementation aligned with existing entities/contracts.
+- **Alternatives considered**:
+  - Add `updatedAt` only.
+  - Add `cast` and `updatedAt`.
+
+## Decision 2: Invalid ID handling
+- **Decision**: Return `400 Bad Request` with `application/problem+json` when `{id}` is not a valid GUID.
+- **Rationale**: Produces explicit client feedback for malformed route input and testable API behavior.
+- **Alternatives considered**:
+  - Return `404 Not Found` for invalid format.
+  - Leave behavior implicit to framework defaults.
+
+## Decision 3: Image field in details contract
+- **Decision**: Use `posterUrl` as the canonical details image field.
+- **Rationale**: Matches existing list contract naming and keeps frontend consumption consistent.
+- **Alternatives considered**:
+  - Expose only relative `image` path.
+  - Expose both `posterUrl` and `image`.
+
+## Decision 4: Frontend navigation scope
+- **Decision**: Ensure all existing movie card/list entry points in frontend navigate to `/movies/{id}`.
+- **Rationale**: Removes UX drift and fulfills issue scope for details-page access.
+- **Alternatives considered**:
+  - Scope navigation changes to catalog only.
+  - Split additional entry points into another issue.

--- a/specs/013-view-movie-details/spec.md
+++ b/specs/013-view-movie-details/spec.md
@@ -1,0 +1,121 @@
+# Feature Specification
+
+## Feature Summary
+
+Implement movie details retrieval and a frontend details page so users can open a movie from catalog/list surfaces and view full metadata for a single movie.
+
+Issue source: https://github.com/marciomyst/SmartMovieCatalog/issues/13
+
+## Problem Statement
+
+The current product allows movie creation and movie listing, but does not provide a details endpoint or details page for a specific movie. Users cannot inspect full movie metadata after selecting a movie from list/card views.
+
+## Goals
+
+- Add `GET /api/movies/{id}` to retrieve one movie by ID.
+- Return a dedicated details DTO with full metadata currently supported by the product.
+- Add a frontend details route/page for movie details.
+- Support loading, not found, and API error states on details UI.
+- Keep backend and frontend contracts synchronized.
+- Preserve the existing dark cinematic frontend direction.
+
+## Clarifications
+
+### Session 2026-05-08
+
+- Q: The issue example includes `cast` and `updatedAt`. Should this feature keep scope to currently supported metadata only, or expand domain/persistence/contracts now? → A: Keep scope to currently supported metadata only; do not add `cast` or `updatedAt` in this issue.
+- Q: For invalid `id` format (non-GUID), what should the API return? → A: Return `400 Bad Request` with `application/problem+json`.
+- Q: Should navigation be implemented only in catalog or across all existing movie cards/list items in frontend? → A: Ensure all existing movie card/list entry points navigate to `/movies/{id}`.
+
+## Non-Goals
+
+- Editing movie data.
+- Poster upload.
+- AI poster analysis fields.
+- Realtime updates.
+- Similar movie recommendations.
+- Semantic search or vector/RAG behavior.
+- Introducing new infrastructure, dependencies, or architecture patterns.
+
+## User Stories
+
+- As a catalog user, I want to open a movie details page from a movie card/list item so I can inspect full metadata.
+- As a catalog user, I want a clear not-found state when a movie does not exist.
+- As a catalog user, I want a clear error state when the API request fails.
+
+## Functional Requirements
+
+- The backend MUST expose `GET /api/movies/{id}`.
+- The endpoint MUST return `200 OK` with `application/json` for existing movies.
+- The endpoint MUST return `404 Not Found` with `application/problem+json` and fields `type`, `title`, `status`, `detail`, and `instance` when a movie is missing.
+- The endpoint MUST return `400 Bad Request` with `application/problem+json` when `{id}` is not a valid GUID.
+- The details response MUST be a dedicated public contract DTO under `SmartMovieCatalog.Contracts`.
+- The details response MUST include full metadata currently supported in the domain/API for movies.
+- The details response MUST NOT introduce new persisted fields such as `cast` or `updatedAt` in this feature.
+- The frontend MUST define a details route/page reachable through `/movies/{id}`.
+- The details page MUST call a typed API service and MUST NOT call `HttpClient` directly in components.
+- The details page MUST display title, release year, genres, director, synopsis, duration, age rating, and available metadata.
+- The details page MUST handle loading state.
+- The details page MUST handle not-found state.
+- The details page MUST handle API failure state.
+- Navigation from movie cards/list items to `/movies/{id}` MUST work.
+- Persistence models MUST NOT be exposed directly through API responses.
+- AI analysis fields MUST NOT be introduced in this feature.
+
+## Acceptance Criteria
+
+- A movie can be retrieved by ID.
+- Existing movie returns `200 OK`.
+- Successful response uses `application/json`.
+- Invalid movie ID format returns `400 Bad Request` with `application/problem+json`.
+- Missing movie returns `404 Not Found`.
+- Missing movie response uses `application/problem+json` with `type`, `title`, `status`, `detail`, and `instance`.
+- The details page displays title, year, genres, director, synopsis, duration, age rating, and available metadata.
+- The UI handles loading state.
+- The UI handles not found state.
+- The UI handles API failure state.
+- Navigation from movie card/list to details works.
+- No persistence model is exposed directly through the API.
+
+## Edge Cases
+
+- Invalid movie ID format in route parameter.
+- Valid GUID format with no corresponding movie in persistence.
+- Movie exists with optional metadata missing (`director`, `synopsis`, `durationMinutes`, `ageRating`, `image`).
+- Movie exists with zero genres.
+- API returns transient server failures while fetching details.
+- User lands directly on `/movies/{id}` via deep link.
+
+## Clarifications Needed
+
+- No open clarifications remain for this feature.
+
+## Assumptions
+
+- "Full metadata currently supported" means fields already present in movie domain/application/contracts, without introducing new data ownership concepts.
+- `posterUrl` in details response can be derived from stored relative movie `image` path (or null when absent), matching listing behavior.
+- The details route pattern remains `/movies/{id}`.
+
+## Dependencies
+
+- Existing movie persistence and listing foundation (`Movie`, `Genre`, EF Core repositories).
+- Existing API error contract using `ProblemDetails` / `ValidationProblemDetails` (ADR 0004).
+- Existing catalog/list navigation flow that already links to `/movies/{id}`.
+- Angular routing and typed API service patterns already used in `frontend/src/app`.
+
+## Risks
+
+- Scope creep if `cast` and `updatedAt` are interpreted as mandatory new persisted fields.
+- Backend/frontend contract drift if details DTO evolves without mirrored frontend models.
+- Not-found behavior inconsistency if endpoint metadata and actual response shaping diverge.
+- Route collisions or UX inconsistency if details page is added without navigation/state alignment.
+
+## Conflicts
+
+- Issue #13 example response includes `cast` and `updatedAt`, which conflicts with the current movie domain model that does not expose those fields; this feature keeps those fields out of scope by decision.
+
+## Out of Scope
+
+- Any create/update/delete movie behavior changes.
+- Any AI analysis, recommendation, or semantic search behavior.
+- Any authentication-specific details-page behavior beyond existing app defaults.

--- a/specs/013-view-movie-details/tasks.md
+++ b/specs/013-view-movie-details/tasks.md
@@ -1,0 +1,180 @@
+# Tasks: View Movie Details
+
+**Input**: Design documents from `/specs/013-view-movie-details/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories)
+
+**Tests**: Test tasks were not included because the feature spec does not explicitly require a TDD or test-first workflow.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and validation of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the feature slice structure and shared contract surface.
+
+- [ ] T001 Create the details contract file `backend/src/SmartMovieCatalog.Contracts/Movies/MovieDetailsResponse.cs`
+- [ ] T002 Create application get-by-id query/handler files under `backend/src/SmartMovieCatalog.Application/Features/Movies/`
+- [ ] T003 [P] Create API endpoint slice folder `backend/src/SmartMovieCatalog.Api/Features/Movies/GetMovieById/`
+- [ ] T004 [P] Create frontend details page folder `frontend/src/app/movies/movie-details-page/`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core backend/frontend foundations required before user story implementation.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T005 Extend repository abstraction with single-movie lookup in `backend/src/SmartMovieCatalog.Application/Abstractions/Persistence/IMovieRepository.cs`
+- [ ] T006 Implement single-movie lookup with genres include in `backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs`
+- [ ] T007 [P] Update application fake repository for new lookup contract in `backend/tests/SmartMovieCatalog.Application.Tests/TestSupport/FakeMovieRepository.cs`
+- [ ] T008 [P] Update API fake repository for new lookup contract in `backend/tests/SmartMovieCatalog.Api.Tests/TestSupport/FakeMovieRepository.cs`
+- [ ] T009 Add frontend details models in `frontend/src/app/movies/movie.models.ts`
+- [ ] T010 Add typed details API method in `frontend/src/app/movies/movies-api.ts`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Open Movie Details From Catalog (Priority: P1) 🎯 MVP
+
+**Goal**: Allow users to open `/movies/{id}` and view full movie metadata.
+
+**Independent Test**: Open `/movies/{id}` for an existing movie and confirm title, year, genres, director, synopsis, duration, age rating, and available metadata render correctly.
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Implement application details projection model in `backend/src/SmartMovieCatalog.Application/Features/Movies/`
+- [ ] T012 [US1] Implement get-by-id query handler orchestration in `backend/src/SmartMovieCatalog.Application/Features/Movies/`
+- [ ] T013 [US1] Implement `GET /api/movies/{id}` endpoint response mapping in `backend/src/SmartMovieCatalog.Api/Features/Movies/GetMovieById/GetMovieByIdEndpoint.cs`
+- [ ] T014 [US1] Register details endpoint mapping in `backend/src/SmartMovieCatalog.Api/Features/Movies/MoviesEndpoints.cs`
+- [ ] T015 [US1] Add details page component logic in `frontend/src/app/movies/movie-details-page/movie-details-page.ts`
+- [ ] T016 [P] [US1] Add details page template in `frontend/src/app/movies/movie-details-page/movie-details-page.html`
+- [ ] T017 [P] [US1] Add details page styling in `frontend/src/app/movies/movie-details-page/movie-details-page.css`
+- [ ] T018 [US1] Register `/movies/:id` route in `frontend/src/main.ts`
+- [ ] T019 [US1] Confirm and adjust catalog navigation links to details in `frontend/src/app/catalog/catalog-page/catalog-page.ts` and `frontend/src/app/catalog/catalog-page/catalog-page.html`
+
+**Checkpoint**: User Story 1 is functional and can be validated independently.
+
+---
+
+## Phase 4: User Story 2 - Show Not Found State (Priority: P2)
+
+**Goal**: Return and render a clear not-found state when the movie does not exist.
+
+**Independent Test**: Open `/movies/{id}` with a valid GUID that does not exist and confirm API returns `404 problem+json` and UI shows a not-found state.
+
+### Implementation for User Story 2
+
+- [ ] T020 [US2] Add application not-found result type in `backend/src/SmartMovieCatalog.Application/Features/Movies/`
+- [ ] T021 [US2] Update get-by-id handler to return success/failure result in `backend/src/SmartMovieCatalog.Application/Features/Movies/`
+- [ ] T022 [US2] Map not-found result to RFC7807 response in `backend/src/SmartMovieCatalog.Api/Features/Movies/GetMovieById/GetMovieByIdEndpoint.cs`
+- [ ] T023 [US2] Add details page not-found state rendering in `frontend/src/app/movies/movie-details-page/movie-details-page.ts` and `frontend/src/app/movies/movie-details-page/movie-details-page.html`
+
+**Checkpoint**: User Story 2 is functional and can be validated independently.
+
+---
+
+## Phase 5: User Story 3 - Show API Failure State (Priority: P3)
+
+**Goal**: Show a clear recoverable error state for request failures other than not-found.
+
+**Independent Test**: Simulate API failure while loading `/movies/{id}` and confirm UI renders error state without crashing.
+
+### Implementation for User Story 3
+
+- [ ] T024 [US3] Add details load-state model for generic failure handling in `frontend/src/app/movies/movie.models.ts`
+- [ ] T025 [US3] Implement HTTP error classification (404 vs other failures) in `frontend/src/app/movies/movie-details-page/movie-details-page.ts`
+- [ ] T026 [US3] Add failure UI state in `frontend/src/app/movies/movie-details-page/movie-details-page.html` and `frontend/src/app/movies/movie-details-page/movie-details-page.css`
+
+**Checkpoint**: User Story 3 is functional and can be validated independently.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency updates across docs and verification.
+
+- [ ] T027 [P] Document new endpoint and response contract in `docs/API.md`
+- [ ] T028 [P] Document frontend route/details behavior in `docs/FRONTEND.md`
+- [ ] T029 Verify backend build and tests from `SmartMovieCatalog.slnx`
+- [ ] T030 Verify frontend build and tests from `frontend/package.json`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - start immediately
+- **Foundational (Phase 2)**: Depends on Setup - blocks all user stories
+- **User Stories (Phases 3-5)**: Depend on Foundational completion
+  - US1 (P1) first for MVP
+  - US2 (P2) depends on US1 endpoint/page baseline
+  - US3 (P3) depends on US1 page load flow baseline
+- **Polish (Phase 6)**: Depends on completion of selected user stories
+
+### User Story Dependencies
+
+- **US1**: Starts after Foundational; no dependency on US2/US3
+- **US2**: Starts after US1 backend/frontend details baseline
+- **US3**: Starts after US1 frontend load flow baseline
+
+### Within Each User Story
+
+- Backend application/repository wiring before API endpoint mapping
+- API response behavior before frontend state rendering
+- Route/navigation wiring after details component is implemented
+
+### Parallel Opportunities
+
+- Phase 1: T003 and T004 can run in parallel
+- Phase 2: T007 and T008 can run in parallel; T009 can run in parallel with backend tasks
+- US1: T016 and T017 can run in parallel after T015 starts
+- Polish: T027 and T028 can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "T016 [US1] Add details page template in frontend/src/app/movies/movie-details-page/movie-details-page.html"
+Task: "T017 [US1] Add details page styling in frontend/src/app/movies/movie-details-page/movie-details-page.css"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 and Phase 2
+2. Complete Phase 3 (US1)
+3. Validate existing movie details end-to-end (`GET /api/movies/{id}` + `/movies/{id}`)
+4. Demo/deploy MVP increment
+
+### Incremental Delivery
+
+1. Deliver US1 (details retrieval + details page)
+2. Deliver US2 (not-found behavior with RFC7807 response + UI state)
+3. Deliver US3 (generic API error state)
+4. Finish docs and verification in Phase 6
+
+### Parallel Team Strategy
+
+1. One developer completes backend foundations (T005-T008) while another prepares frontend foundations (T009-T010)
+2. After foundations, backend/API and frontend details UI can progress in parallel for US1
+3. US2 backend mapping and US3 frontend error UX can proceed in parallel after US1 baseline
+
+---
+
+## Notes
+
+- [P] tasks are file-disjoint and can be executed in parallel safely.
+- All user story tasks include `[US#]` labels for traceability.
+- Tasks are intentionally scoped to existing architecture and supported metadata only.

--- a/specs/025-normalize-movie-genres/.spec-context.json
+++ b/specs/025-normalize-movie-genres/.spec-context.json
@@ -4,7 +4,18 @@
   "branch": "025-normalize-movie-genres",
   "selectedAt": "2026-05-07T22:22:29.451Z",
   "currentStep": "specify",
-  "status": "draft",
+  "status": "completed",
   "stepHistory": {},
-  "transitions": []
+  "transitions": [
+    {
+      "step": "specify",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-09T00:34:53.317Z"
+    }
+  ]
 }


### PR DESCRIPTION
## What changed

Implements movie details end to end for issue 13.

- Adds the backend `GET /api/movies/{id}` endpoint with typed success and ProblemDetails responses.
- Adds application and repository support for loading a movie by ID with genres.
- Adds the public movie details contract using `posterUrl`.
- Adds Angular typed service/model support and the `/movies/:id` details page.
- Makes movie cards navigate to the details route.
- Updates Spec Kit artifacts and documentation for the feature.
- Aligns the Angular project location in the Visual Studio solution file.

## Impact

Users can click a movie card in the catalog and view a dedicated details screen with poster, metadata, synopsis, and handled loading/error/not-found states.

## Validation

- `dotnet build SmartMovieCatalog.slnx`
- Earlier in the branch: backend tests, frontend build, and frontend tests were run while implementing the feature.

## Notes

The latest solution build succeeded with warnings from npm package audit and transient Visual Studio/API file locks, but no build errors.