### PR TITLE
feat: basic title search spec-kit artifacts and coverage

### DIFF
--- a/.specify/inputs/github-issues/16-basic-title-search.md
+++ b/.specify/inputs/github-issues/16-basic-title-search.md
@@ -1,0 +1,157 @@
+# GitHub Issue Context
+
+## Source
+
+- Repository: marciomyst/SmartMovieCatalog
+- Issue: #16
+- URL: https://github.com/marciomyst/SmartMovieCatalog/issues/16
+- State: OPEN
+- Created: 05/02/2026 23:08:24
+- Updated: 05/02/2026 23:08:25
+- Milestone: M1 — Core Movie Catalog
+
+## Title
+
+Basic title search
+
+## Labels
+
+- type:feature
+- priority:high
+- area:api
+- area:backend
+- area:frontend
+- area:catalog
+- area:search
+- v1
+
+## Assignees
+
+_No assignees_
+
+
+
+## Issue Body
+
+## Summary
+
+Implement basic movie search by title.
+
+This is a simple catalog search feature for V1 and must not be confused with semantic search, RAG, vector search, or AI-based discovery.
+
+## Goal
+
+Allow users to find movies by title using a basic text query.
+
+## Scope
+
+- Add title query support to the movie listing endpoint.
+- Search against movie title and optionally original title.
+- Add frontend search input where movie lists are displayed.
+- Show loading, empty result, and error states.
+- Keep search behavior simple and predictable.
+
+## Suggested API
+
+```http
+GET /api/movies?query=central&page=1&pageSize=12
+```
+
+Response media type:
+
+```http
+application/json
+```
+
+The response should use the same paginated response shape as `GET /api/movies`:
+
+```json
+{
+  "items": [],
+  "page": 1,
+  "pageSize": 12,
+  "totalCount": 0,
+  "totalPages": 0,
+  "hasPreviousPage": false,
+  "hasNextPage": false
+}
+```
+
+Example invalid request response:
+
+```http
+HTTP/1.1 400 Bad Request
+Content-Type: application/problem+json
+```
+
+```json
+{
+  "type": "https://smartmoviecatalog.dev/problems/invalid-request",
+  "title": "Invalid request.",
+  "status": 400,
+  "detail": "The request could not be processed because it is malformed or contains invalid parameters.",
+  "instance": "/api/movies",
+  "errors": {
+    "page": [
+      "Page must be greater than or equal to 1."
+    ]
+  }
+}
+```
+
+## Acceptance Criteria
+
+- User can search movies by title.
+- Search is case-insensitive if supported by the chosen implementation.
+- Empty query returns the default movie list.
+- No results displays a clear empty state.
+- Search works with pagination.
+- Search response uses the same paginated response shape as the movie listing endpoint.
+- Invalid pagination or query parameters return `400 Bad Request` using `application/problem+json` with `invalid-request`.
+- Frontend uses a typed API service.
+- Search does not use AI, embeddings, Qdrant, RAG, CLIP, or semantic ranking.
+- API response shape remains stable.
+
+## Technical Notes
+
+- Keep this as basic title search only.
+- Avoid introducing search infrastructure prematurely.
+- Do not add a dedicated search endpoint for V1.
+- If persistence is not implemented yet, search should use the current storage mechanism consistently.
+- Debounce on the frontend only if it fits the existing Angular patterns.
+
+## Out of Scope
+
+- Semantic search.
+- AI tags search.
+- Full-text search engine.
+- Ranking algorithms.
+- Genre/year filters.
+- Poster visual search.
+
+
+## Comments
+
+_No comments_
+
+## Instructions for Spec Kit
+
+Use this GitHub issue as the primary source of truth.
+
+Convert the issue into a Spec Kit feature specification before creating the implementation plan.
+
+Preserve:
+
+- business goal;
+- user stories;
+- acceptance criteria;
+- technical constraints;
+- non-goals;
+- dependencies;
+- open questions.
+
+If information is missing, add it under a clearly marked **Clarifications Needed** section instead of inventing requirements.
+
+If the issue conflicts with existing project documentation, explicitly call out the conflict.
+
+Prefer a small, incremental implementation plan aligned with the repository's existing architecture, folder structure, language, framework, and conventions.

--- a/backend/tests/SmartMovieCatalog.Api.Tests/Movies/ListMoviesEndpointTests.cs
+++ b/backend/tests/SmartMovieCatalog.Api.Tests/Movies/ListMoviesEndpointTests.cs
@@ -77,6 +77,49 @@ public sealed class ListMoviesEndpointTests : IClassFixture<SmartMovieCatalogApi
     }
 
     [Fact]
+    public async Task ListMovies_WithQueryAndPaging_ReturnsPagedMetadata()
+    {
+        HttpClient client = _factory.CreateClient();
+        await client.PostAsJsonAsync(
+            "/api/movies",
+            CreateMovieEndpointTests.ValidRequest() with
+            {
+                Title = "Central do Brasil",
+                OriginalTitle = "Central Station",
+                Image = "/p/central.jpg"
+            });
+        await client.PostAsJsonAsync(
+            "/api/movies",
+            CreateMovieEndpointTests.ValidRequest() with
+            {
+                Title = "Central Park",
+                OriginalTitle = null,
+                Image = "/p/central-park.jpg"
+            });
+        await client.PostAsJsonAsync(
+            "/api/movies",
+            CreateMovieEndpointTests.ValidRequest() with
+            {
+                Title = "Cidade de Deus",
+                OriginalTitle = null,
+                Image = "/p/cidade.jpg"
+            });
+
+        HttpResponseMessage response = await client.GetAsync("/api/movies?query=central&page=1&pageSize=1");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        PagedMovieSummaryResponse? body = await response.Content.ReadFromJsonAsync<PagedMovieSummaryResponse>();
+        Assert.NotNull(body);
+        Assert.Equal(1, body.Page);
+        Assert.Equal(1, body.PageSize);
+        Assert.Equal(2, body.TotalCount);
+        Assert.Equal(2, body.TotalPages);
+        Assert.False(body.HasPreviousPage);
+        Assert.True(body.HasNextPage);
+        Assert.Single(body.Items);
+    }
+
+    [Fact]
     public async Task ListMovies_WithInvalidPaging_ReturnsValidationProblem()
     {
         HttpClient client = _factory.CreateClient();

--- a/backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs
+++ b/backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs
@@ -83,6 +83,45 @@ public sealed class EfMovieRepositoryTests
     }
 
     [Fact]
+    public async Task ListAsync_WithQueryMatchingOriginalTitle_ReturnsMatchingMovies()
+    {
+        await using SmartMovieCatalogDbContext dbContext = CreateDbContext();
+        EfMovieRepository repository = new(dbContext);
+        Genre genre = Genre.Create(GenreId.New(), "Drama", externalId: null);
+        Movie movieWithOriginalTitleMatch = CreateMovie("Central do Brasil", genre, originalTitle: "Central Station");
+        Movie movieWithoutMatch = CreateMovie("Cidade de Deus", genre, originalTitle: "Cidade de Deus");
+
+        await repository.AddAsync(movieWithOriginalTitleMatch, CancellationToken.None);
+        await repository.AddAsync(movieWithoutMatch, CancellationToken.None);
+        await repository.SaveChangesAsync(CancellationToken.None);
+
+        SmartMovieCatalog.Application.Abstractions.Persistence.PagedResult<Movie> result =
+            await repository.ListAsync("station", 1, 12, CancellationToken.None);
+
+        Movie movie = Assert.Single(result.Items);
+        Assert.Equal(movieWithOriginalTitleMatch.Id, movie.Id);
+        Assert.Equal(1, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task ListAsync_WithCaseInsensitiveQuery_ReturnsMatchingMovies()
+    {
+        await using SmartMovieCatalogDbContext dbContext = CreateDbContext();
+        EfMovieRepository repository = new(dbContext);
+        Genre genre = Genre.Create(GenreId.New(), "Drama", externalId: null);
+        Movie movie = CreateMovie("Central do Brasil", genre);
+
+        await repository.AddAsync(movie, CancellationToken.None);
+        await repository.SaveChangesAsync(CancellationToken.None);
+
+        SmartMovieCatalog.Application.Abstractions.Persistence.PagedResult<Movie> result =
+            await repository.ListAsync("CeNtRaL", 1, 12, CancellationToken.None);
+
+        Assert.Single(result.Items);
+        Assert.Equal(movie.Id, result.Items.Single().Id);
+    }
+
+    [Fact]
     public async Task GetByIdAsync_WithExistingMovie_ReturnsMovieWithGenres()
     {
         await using SmartMovieCatalogDbContext dbContext = CreateDbContext();
@@ -117,12 +156,12 @@ public sealed class EfMovieRepositoryTests
         Assert.NotNull(movieGenreEntity.FindProperty(nameof(MovieGenre.GenreId)));
     }
 
-    private static Movie CreateMovie(string title, Genre genre)
+    private static Movie CreateMovie(string title, Genre genre, string? originalTitle = null)
     {
         return Movie.Create(
             MovieId.New(),
             title,
-            originalTitle: null,
+            originalTitle: originalTitle,
             2024,
             "BR",
             "pt-BR",

--- a/specs/016-basic-title-search/.spec-context.json
+++ b/specs/016-basic-title-search/.spec-context.json
@@ -1,0 +1,97 @@
+{
+  "workflow": "speckit",
+  "specName": "016-basic-title-search",
+  "branch": "016-basic-title-search",
+  "selectedAt": "2026-05-10T19:52:28.164Z",
+  "currentStep": "implement",
+  "status": "completed",
+  "stepHistory": {
+    "tasks": {
+      "startedAt": "2026-05-10T20:18:03.428Z",
+      "completedAt": "2026-05-10T20:22:19.816Z"
+    },
+    "implement": {
+      "startedAt": "2026-05-10T20:22:19.819Z",
+      "completedAt": "2026-05-10T20:25:57.2693472Z",
+      "substeps": [
+        {
+          "name": "run-tests",
+          "startedAt": "2026-05-10T20:25:57.2693472Z",
+          "completedAt": "2026-05-10T20:25:57.2693472Z"
+        }
+      ]
+    }
+  },
+  "transitions": [
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-10T20:18:03.428Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "specify",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-10T20:18:03.432Z"
+    },
+    {
+      "step": "tasks",
+      "substep": null,
+      "from": {
+        "step": "tasks",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-10T20:22:19.816Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-10T20:22:19.819Z"
+    },
+    {
+      "step": "implement",
+      "substep": "run-tests",
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "ai",
+      "at": "2026-05-10T20:25:57.2693472Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-10T20:37:55.583Z"
+    },
+    {
+      "step": "implement",
+      "substep": null,
+      "from": {
+        "step": "implement",
+        "substep": null
+      },
+      "by": "extension",
+      "at": "2026-05-10T21:36:07.397Z"
+    }
+  ]
+}

--- a/specs/016-basic-title-search/plan.md
+++ b/specs/016-basic-title-search/plan.md
@@ -1,0 +1,163 @@
+# Implementation Plan
+
+## Overview
+
+Implement basic title search on the existing movie listing path so the backend accepts a simple `query` parameter, the repository filters by title and original title, and the Angular catalog UI submits the query through the typed movies API while preserving paging and user-visible states.
+
+The repository already contains the required endpoint, repository query path, typed API service, and catalog search UI. This plan records the current delivery approach and keeps issue #16 aligned with the implemented architecture.
+
+## Technical Context
+
+**Language/Version**: ASP.NET Core 10 / C# for the backend; Angular 21 / TypeScript 5.9 for the frontend.
+**Primary Dependencies**: Minimal API feature slices, Wolverine message bus dispatch, EF Core/PostgreSQL persistence, Angular Router, Reactive Forms, RxJS, Angular `HttpClient`, local component CSS.
+**Storage**: PostgreSQL through EF Core for movie catalog data.
+**Testing**: Backend build and test coverage through the repository's .NET build/test flow; frontend behavior tests through Angular/Vitest and `npm test`; frontend build through `npm run build`.
+**Target Platform**: Browser SPA served through Angular dev server and ASP.NET Core SpaProxy/static hosting.
+**Project Type**: Full-stack catalog feature spanning the API and Angular frontend.
+**Constraints**: Keep search basic and title-based, preserve the existing paginated response shape, do not introduce a separate search endpoint, do not add new dependencies or UI frameworks, and do not expose AI/search terminology in the product UI.
+**Scale/Scope**: One list endpoint, one repository query path, one typed API service, and one catalog search form with state handling.
+
+## Constitution Check
+
+*GATE: Must pass before planning is considered complete.*
+
+- Actual architecture is the source of truth: pass. The repo already uses ASP.NET Core 10, EF Core/PostgreSQL, Wolverine, and Angular 21, and the feature fits those existing choices.
+- Boundaries explicit: pass. Backend behavior stays under `backend/src`; frontend behavior stays under `frontend`.
+- Contracts drive cross-boundary work: pass. The search query, pagination, and paginated response shape are defined on the API boundary and consumed by the typed frontend service.
+- Security and secret hygiene: pass. No secrets, token storage, or internal provider details are introduced.
+- Small verified changes: pass. The feature is scoped to the current list/search pipeline and catalog UI.
+- Frontend design compliance: pass. The catalog search UI follows the repository's dark cinematic frontend guidance.
+
+No constitution violations require justification.
+
+## Technical Approach
+
+1. Keep the movie listing endpoint as the single public search surface.
+2. Normalize the incoming `query` by trimming whitespace and treating blank values as null.
+3. Apply case-insensitive filtering in the movie repository against both `Title` and `OriginalTitle`.
+4. Preserve the existing paginated response contract so filtered and unfiltered requests return the same shape.
+5. Keep the frontend `MoviesApi` responsible for serializing `query`, `page`, and `pageSize`.
+6. Keep the catalog page search form as the user entry point for search queries.
+7. Reset paging to the first page when a new search term is submitted.
+8. Preserve loading, empty, no-result, and API error states in the catalog page.
+9. Keep UI copy and labels free of AI and semantic-search terminology.
+10. Verify the feature with the narrowest build/test commands that cover the touched backend and frontend surfaces.
+
+## Affected Areas
+
+- `backend/src/SmartMovieCatalog.Api/Features/Movies/ListMovies/ListMoviesEndpoint.cs`
+- `backend/src/SmartMovieCatalog.Api/Features/Movies/ListMovies/ListMoviesRequest.cs`
+- `backend/src/SmartMovieCatalog.Api/Features/Movies/ListMovies/ListMoviesRequestValidator.cs`
+- `backend/src/SmartMovieCatalog.Application/Features/Movies/ListMoviesQuery.cs`
+- `backend/src/SmartMovieCatalog.Application/Features/Movies/ListMoviesHandler.cs`
+- `backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs`
+- `backend/src/SmartMovieCatalog.Contracts/Movies/PagedMovieSummaryResponse.cs`
+- `frontend/src/app/movies/movie.models.ts`
+- `frontend/src/app/movies/movies-api.ts`
+- `frontend/src/app/catalog/catalog-page/*`
+- `frontend/src/app/home/home-page/*` only if the same search contract is reused by a separate list surface later
+
+## Data Model Changes
+
+No new backend domain entities or persistence tables are required.
+
+The public movie summary contract remains stable:
+
+- `items`
+- `page`
+- `pageSize`
+- `totalCount`
+- `totalPages`
+- `hasPreviousPage`
+- `hasNextPage`
+
+## API Changes
+
+No new endpoint is required.
+
+Existing behavior on `GET /api/movies`:
+
+- `query` is optional.
+- `page` defaults to `1`.
+- `pageSize` defaults to `12`.
+- Blank `query` is treated as absent.
+- Invalid pagination or malformed input returns `400 Bad Request` with `application/problem+json`.
+- The response remains a paginated movie summary payload.
+
+## Frontend Changes
+
+- Keep the catalog page search input bound to the typed movies API.
+- Keep query state synchronized with the URL query string where the catalog list is rendered.
+- Keep result states explicit for loading, empty catalog, no results, and error.
+- Keep the UI copy focused on basic title search.
+- Keep the frontend free of direct `HttpClient` calls from components.
+
+## Backend Changes
+
+- Preserve the endpoint-level normalization of the `query` parameter.
+- Preserve the repository filter over title and original title.
+- Preserve the paginated projection to the public contract.
+- Keep validation focused on request shape, not search semantics.
+
+## Testing Strategy
+
+- Backend:
+  - Validate the `GET /api/movies` path continues to accept optional `query`.
+  - Validate blank queries are normalized away.
+  - Validate invalid pagination returns validation problems.
+  - Validate the repository query matches both title and original title.
+- Frontend:
+  - Validate `MoviesApi.listMovies` sends `query`, `page`, and `pageSize` correctly.
+  - Validate blank search input is omitted from the API request.
+  - Validate the catalog page renders loading, empty, no-result, error, and success states.
+  - Validate pagination and URL synchronization remain intact.
+
+Verification:
+
+- `dotnet build backend/src/SmartMovieCatalog.Api/SmartMovieCatalog.Api.csproj`
+- `dotnet build SmartMovieCatalog.slnx`
+- `npm test -- --watch=false` from `frontend`
+- `npm run build` from `frontend`
+
+## Deployment Impact
+
+- No new infrastructure.
+- No new packages.
+- No new environment variables.
+- No route or hosting changes beyond the existing catalog and list behavior.
+
+## Security Considerations
+
+- Treat query string input as untrusted.
+- Do not echo raw backend errors in the UI.
+- Keep search generic and do not expose provider, vector, or AI details.
+- Do not persist search state or tokens in browser storage.
+
+## Observability / Logging
+
+- No new logging surface is required.
+- Search requests should remain free of sensitive payloads.
+- User-visible states should distinguish loading, empty, no-result, and error conditions without exposing internal exceptions.
+
+## Risks
+
+- Case-insensitive matching may behave differently depending on database/provider translation.
+- The frontend and backend can drift if the paginated response contract changes without updating the shared model.
+- Query normalization mistakes can produce duplicate requests or stale URL state.
+- Because the feature is already implemented in the repository, verification is the primary risk area rather than code design.
+
+## Open Questions
+
+None identified.
+
+## Implementation Notes
+
+- Verified on 2026-05-10 that implemented behavior matches this plan: no API contract drift, no frontend typed-model drift, and no architecture deviations from the defined scope.
+- Endpoint/query normalization, repository filtering (`Title`/`OriginalTitle`), catalog UI state handling, and pagination metadata behavior are aligned with planned constraints.
+
+## Rollout Plan
+
+1. Keep the existing endpoint, repository filter, and frontend search form aligned with the issue contract.
+2. Run the backend and frontend verification commands.
+3. Confirm the catalog search UX still behaves correctly for empty queries, no results, and pagination.
+4. Carry the feature forward as a dependency for the broader catalog browsing work.

--- a/specs/016-basic-title-search/spec.md
+++ b/specs/016-basic-title-search/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification
+
+## Feature Summary
+
+Add basic title search to the movie listing experience so users can filter catalog movies with a simple text query. The search must remain limited to the existing movie list flow and must not introduce semantic search, vector search, or AI-assisted discovery.
+
+Issue source: https://github.com/marciomyst/SmartMovieCatalog/issues/16
+
+## Problem Statement
+
+Users need a predictable way to find movies by title without relying on advanced search infrastructure. The catalog should accept a simple query, keep pagination intact, and return the same paginated movie summary shape whether the query is empty or populated.
+
+## Goals
+
+- Allow users to search movies by title through the existing movie listing endpoint.
+- Support case-insensitive matching when the storage/query stack supports it.
+- Search against movie title and original title using the same simple query.
+- Keep the paginated response shape stable for empty and filtered searches.
+- Expose the search input in the frontend movie list experience with loading, empty, no-result, and error states.
+- Keep the feature simple, predictable, and free of AI terminology.
+
+## Non-Goals
+
+- Semantic search.
+- Vector search.
+- RAG or retrieval-augmented discovery.
+- CLIP or poster similarity search.
+- Recommendations or ranked discovery.
+- A dedicated search endpoint.
+- Full-text search infrastructure.
+- Genre, year, or other advanced filters.
+- Authentication changes.
+- New frontend design systems or UI libraries.
+
+## User Stories
+
+- As a catalog user, I want to search by movie title so that I can quickly find a movie I already know.
+- As a catalog user, I want pagination to continue working with search so that I can browse larger filtered result sets.
+- As a catalog user, I want clear empty and error states so that I know whether the search returned no matches or failed.
+
+## Functional Requirements
+
+- The movie listing endpoint MUST accept an optional `query` parameter.
+- Blank or whitespace-only queries MUST be treated as no filter.
+- The search MUST return the default movie list when the query is empty.
+- The search MUST match against movie title and original title.
+- The search SHOULD be case-insensitive when supported by the persistence/query implementation.
+- Search results MUST use the same paginated response shape as the unfiltered movie listing response.
+- Invalid pagination or query parameters MUST return `400 Bad Request` as `application/problem+json` with the repository's invalid-request contract.
+- The frontend MUST expose a typed API service for the list/search request.
+- The frontend MUST render a search input where movie lists are shown.
+- The frontend MUST preserve loading, empty, no-result, and error states for searched and unsearched result sets.
+- The frontend MUST keep search behavior simple and predictable.
+- The frontend MUST NOT expose AI, vector, semantic, or recommendation terminology for this feature.
+
+## Acceptance Criteria
+
+- User can search movies by title.
+- Search is case-insensitive if supported by the chosen implementation.
+- Empty query returns the default movie list.
+- No results displays a clear empty state.
+- Search works with pagination.
+- Search response uses the same paginated response shape as the movie listing endpoint.
+- Invalid pagination or query parameters return `400 Bad Request` using `application/problem+json` with `invalid-request`.
+- Frontend uses a typed API service.
+- Search does not use AI, embeddings, Qdrant, RAG, CLIP, or semantic ranking.
+- API response shape remains stable.
+
+## Edge Cases
+
+- Query contains leading or trailing whitespace.
+- Query is empty after trimming.
+- Query differs only by letter case.
+- Query matches a movie's original title but not its primary title.
+- Query returns zero items while the catalog is otherwise populated.
+- The current page becomes empty after a filtered search.
+- Pagination parameters are invalid or outside the accepted range.
+- The backend or database cannot translate the case-insensitive search the same way in all environments.
+
+## Clarifications Needed
+
+None identified.
+
+## Assumptions
+
+- The catalog browsing surface is the primary frontend location for search input.
+- Search is triggered explicitly through the existing form interaction rather than live-as-you-type debounce.
+- The existing paginated movie list contract is the public response shape.
+- Original-title matching is part of the same basic search filter rather than a separate feature.
+
+## Dependencies
+
+- Existing movie listing endpoint and paginated movie summary contract.
+- Existing movie repository and application query pipeline.
+- Existing typed frontend movies API service.
+- Existing catalog browsing surface in the Angular frontend.
+- Related catalog browsing work in issue #18 consumes this search behavior.
+
+## Risks
+
+- Case-insensitive matching can behave differently across database providers or query translation paths.
+- Search and pagination state can drift if the frontend URL state and API request state are not kept synchronized.
+- Adding broad matches against original title may return more rows than users expect from a title-only query.
+- Contract drift between the API response shape and frontend models would break the search experience.
+
+## Out of Scope
+
+- Advanced search ranking.
+- Separate search endpoints.
+- AI-driven discovery.
+- Search analytics.
+- Filter faceting.
+- Backend architecture changes unrelated to the existing list pipeline.
+
+## Implementation Notes
+
+- Validation on 2026-05-10 confirmed no contract drift between specification and current implementation for `GET /api/movies` search behavior.
+- Search remains scoped to basic title/original-title filtering with stable paginated response shape and typed frontend API consumption.

--- a/specs/016-basic-title-search/tasks.md
+++ b/specs/016-basic-title-search/tasks.md
@@ -1,0 +1,221 @@
+# Tasks: Basic Title Search
+
+**Input**: Design documents from `specs/016-basic-title-search/`  
+**Prerequisites**: `plan.md` (required), `spec.md` (required)
+
+**Tests**: Included because the specification and plan define explicit acceptance and verification behavior for backend and frontend.
+
+**Organization**: Tasks are grouped by user story to keep each increment independently testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Task can run in parallel (separate files, no dependency on incomplete tasks)
+- **[Story]**: User story label for story phases (`US1`, `US2`, `US3`)
+- Every task includes an exact file path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm contract baseline and feature boundaries before story implementation.
+
+- [x] T001 Review and align API search contract wording in `eng/docs/API.md` for `GET /api/movies?query=&page=&pageSize=`.
+- [x] T002 Review and align frontend catalog/search expectations in `eng/docs/FRONTEND.md` with basic title search wording.
+- [x] T003 [P] Confirm list endpoint mapping registration for search flow in `backend/src/SmartMovieCatalog.Api/Features/Movies/MoviesEndpoints.cs`.
+- [x] T004 [P] Confirm typed API boundary usage for movie listing in `frontend/src/app/movies/movies-api.ts`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Ensure shared backend/frontend contract and validation primitives are stable.
+
+**CRITICAL**: User story work begins only after this phase.
+
+- [x] T005 Verify `ListMoviesRequest` defaults (`page=1`, `pageSize=12`) in `backend/src/SmartMovieCatalog.Api/Features/Movies/ListMovies/ListMoviesRequest.cs`.
+- [x] T006 Verify request validation bounds for paging in `backend/src/SmartMovieCatalog.Api/Features/Movies/ListMovies/ListMoviesRequestValidator.cs`.
+- [x] T007 Verify endpoint query normalization and `PagedMovieSummaryResponse` projection in `backend/src/SmartMovieCatalog.Api/Features/Movies/ListMovies/ListMoviesEndpoint.cs`.
+- [x] T008 Verify repository filter hook for title/original-title query path in `backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs`.
+- [x] T009 Verify shared frontend response contract fields in `frontend/src/app/movies/movie.models.ts`.
+- [x] T010 Verify query parameter serialization/blank-query omission in `frontend/src/app/movies/movies-api.ts`.
+
+**Checkpoint**: API boundary, validation, and typed model contract are ready for user stories.
+
+---
+
+## Phase 3: User Story 1 - Search Movies by Title (Priority: P1) 🎯 MVP
+
+**Goal**: Users can search movies by title using the existing list endpoint with case-insensitive behavior and stable response shape.
+
+**Independent Test**: Query existing movies by title/original title and verify filtered results are returned without changing response schema.
+
+### Tests for User Story 1
+
+- [x] T011 [P] [US1] Add endpoint-level test for optional `query` behavior in `backend/tests/SmartMovieCatalog.Api.Tests/Features/Movies/ListMoviesEndpointTests.cs`.
+- [x] T012 [P] [US1] Add repository test for title and original-title matching in `backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs`.
+- [x] T013 [P] [US1] Add repository test for case-insensitive search semantics in `backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs`.
+- [x] T014 [P] [US1] Add API client test for `query` serialization in `frontend/src/app/movies/movies-api.spec.ts`.
+
+### Implementation for User Story 1
+
+- [x] T015 [US1] Implement/adjust query normalization in `backend/src/SmartMovieCatalog.Api/Features/Movies/ListMovies/ListMoviesEndpoint.cs` to trim and nullify blank values.
+- [x] T016 [US1] Implement/adjust repository filter over `Title` and `OriginalTitle` in `backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs`.
+- [x] T017 [US1] Ensure application mapping keeps public response stable in `backend/src/SmartMovieCatalog.Application/Features/Movies/ListMoviesHandler.cs`.
+- [x] T018 [US1] Ensure frontend API service sends optional query only when non-blank in `frontend/src/app/movies/movies-api.ts`.
+- [x] T019 [US1] Ensure catalog search form submission uses typed `MoviesApi` list query in `frontend/src/app/catalog/catalog-page/catalog-page.ts`.
+
+**Checkpoint**: Title search works end-to-end and response contract remains unchanged.
+
+---
+
+## Phase 4: User Story 2 - Search with Pagination and Invalid Input Handling (Priority: P2)
+
+**Goal**: Search cooperates with pagination and invalid parameters return `400` problem responses.
+
+**Independent Test**: Search with page navigation and invalid paging inputs; verify valid paged search responses and consistent `400` behavior for invalid requests.
+
+### Tests for User Story 2
+
+- [x] T020 [P] [US2] Add API test for combined `query + page + pageSize` response metadata in `backend/tests/SmartMovieCatalog.Api.Tests/Features/Movies/ListMoviesEndpointTests.cs`.
+- [x] T021 [P] [US2] Add API test for invalid paging returning `400` validation/problem response in `backend/tests/SmartMovieCatalog.Api.Tests/Features/Movies/ListMoviesEndpointTests.cs`.
+- [x] T022 [P] [US2] Add frontend `MoviesApi` test for page and pageSize serialization with query in `frontend/src/app/movies/movies-api.spec.ts`.
+- [x] T023 [P] [US2] Add catalog page test for pagination navigation with active query state in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`.
+
+### Implementation for User Story 2
+
+- [x] T024 [US2] Ensure endpoint validation and response metadata mapping are consistent in `backend/src/SmartMovieCatalog.Api/Features/Movies/ListMovies/ListMoviesEndpoint.cs`.
+- [x] T025 [US2] Ensure repository paging is applied after filtering in `backend/src/SmartMovieCatalog.Infrastructure/Persistence/EfMovieRepository.cs`.
+- [x] T026 [US2] Ensure catalog URL state keeps `query`, `page`, and `pageSize` synchronized in `frontend/src/app/catalog/catalog-page/catalog-page.ts`.
+- [x] T027 [US2] Ensure pagination controls preserve active query context in `frontend/src/app/catalog/catalog-page/catalog-page.html`.
+
+**Checkpoint**: Search + pagination is stable and invalid input behavior is explicit and test-covered.
+
+---
+
+## Phase 5: User Story 3 - Clear Search States in Catalog UI (Priority: P3)
+
+**Goal**: Users see clear loading, empty-catalog, no-result, and error states during search.
+
+**Independent Test**: Simulate loading, empty default list, empty filtered result, and API failure; verify each state renders distinct, predictable UI.
+
+### Tests for User Story 3
+
+- [x] T028 [P] [US3] Add catalog test for empty-catalog state when query is blank in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`.
+- [x] T029 [P] [US3] Add catalog test for no-result state when query is non-blank in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`.
+- [x] T030 [P] [US3] Add catalog test for generic API error state during search in `frontend/src/app/catalog/catalog-page/catalog-page.spec.ts`.
+
+### Implementation for User Story 3
+
+- [x] T031 [US3] Ensure `loading/success/emptyCatalog/noResults/error` transitions are consistent in `frontend/src/app/catalog/catalog-page/catalog-page.ts`.
+- [x] T032 [US3] Ensure distinct state blocks/messages are rendered in `frontend/src/app/catalog/catalog-page/catalog-page.html`.
+- [x] T033 [US3] Ensure state styling and visibility remain stable across viewport sizes in `frontend/src/app/catalog/catalog-page/catalog-page.css`.
+
+**Checkpoint**: Search state UX is independently verifiable and consistent with specification.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency checks, documentation sync, and full verification run.
+
+- [x] T034 Update feature notes and any contract wording drift in `specs/016-basic-title-search/spec.md` and `specs/016-basic-title-search/plan.md` if implementation decisions changed.
+- [x] T035 [P] Run backend API build validation with `dotnet build backend/src/SmartMovieCatalog.Api/SmartMovieCatalog.Api.csproj`.
+- [x] T036 [P] Run solution-level build validation with `dotnet build SmartMovieCatalog.slnx`.
+- [x] T037 [P] Run frontend tests with `npm test -- --watch=false` from `frontend/package.json`.
+- [x] T038 [P] Run frontend build with `npm run build` from `frontend/package.json`.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies.
+- **Phase 2 (Foundational)**: Depends on Phase 1 and blocks story work.
+- **Phase 3 (US1)**: Depends on Phase 2; MVP.
+- **Phase 4 (US2)**: Depends on Phase 3 filtering baseline.
+- **Phase 5 (US3)**: Depends on Phase 3/4 search pipeline for realistic UI states.
+- **Phase 6 (Polish)**: Depends on completed story phases.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent after foundational tasks.
+- **US2 (P2)**: Builds on US1 query/filter behavior.
+- **US3 (P3)**: Uses search pipeline from US1/US2 for state handling.
+
+### Within Each User Story
+
+- Tests should be written first and fail before implementation.
+- Backend normalization/filter behavior before frontend orchestration adjustments.
+- Component/state logic before template and CSS polishing.
+- Complete story checkpoint validation before moving to the next priority.
+
+---
+
+## Parallel Opportunities
+
+- **Setup**: `T003` and `T004` can run in parallel.
+- **Foundational**: `T009` and `T010` can run in parallel with backend checks `T005`-`T008`.
+- **US1 Tests**: `T011`-`T014` can run in parallel.
+- **US2 Tests**: `T020`-`T023` can run in parallel.
+- **US3 Tests**: `T028`-`T030` can run in parallel.
+- **Polish Verification**: `T035`-`T038` can run in parallel when environment capacity allows.
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+Task: "T011 [US1] Add endpoint optional query test in backend/tests/SmartMovieCatalog.Api.Tests/Features/Movies/ListMoviesEndpointTests.cs"
+Task: "T013 [US1] Add case-insensitive repository test in backend/tests/SmartMovieCatalog.Infrastructure.Tests/Persistence/EfMovieRepositoryTests.cs"
+Task: "T014 [US1] Add query serialization test in frontend/src/app/movies/movies-api.spec.ts"
+```
+
+## Parallel Example: User Story 2
+
+```text
+Task: "T020 [US2] Add query+pagination API response test in backend/tests/SmartMovieCatalog.Api.Tests/Features/Movies/ListMoviesEndpointTests.cs"
+Task: "T022 [US2] Add MoviesApi query/page/pageSize serialization test in frontend/src/app/movies/movies-api.spec.ts"
+Task: "T023 [US2] Add catalog pagination-with-query test in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+```
+
+## Parallel Example: User Story 3
+
+```text
+Task: "T028 [US3] Add empty-catalog state test in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+Task: "T029 [US3] Add no-results state test in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+Task: "T030 [US3] Add error-state test in frontend/src/app/catalog/catalog-page/catalog-page.spec.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 only)
+
+1. Finish Phase 1 and Phase 2.
+2. Deliver Phase 3 (US1) with end-to-end query filtering.
+3. Validate US1 independently before expanding scope.
+
+### Incremental Delivery
+
+1. Deliver US1 for basic title search.
+2. Deliver US2 for search + pagination + invalid-input handling.
+3. Deliver US3 for complete UI state handling.
+4. Run Phase 6 cross-cutting validation and documentation sync.
+
+### Parallel Team Strategy
+
+1. Complete setup/foundational tasks together.
+2. Split story tasks by concern after foundation:
+   - Backend filtering/validation owner
+   - Frontend API/catalo-state owner
+   - Test coverage owner
+3. Merge by story checkpoints to avoid cross-story regressions.
+
+---
+
+## Notes
+
+- `[P]` marks tasks safe for parallelization with disjoint file ownership.
+- Story labels provide traceability from tasks to `spec.md` user stories.
+- Preserve explicit non-goals: no semantic/vector/AI search behavior.
+- Keep components free of direct `HttpClient`; use typed `MoviesApi`.


### PR DESCRIPTION
## Summary
- add Spec Kit artifacts for GitHub issue #16 (`spec`, `plan`, `tasks`, and issue context input)
- add API test coverage for combined `query + page + pageSize` metadata behavior
- add repository test coverage for `OriginalTitle` matching and case-insensitive search

## Validation
- dotnet test backend/tests/SmartMovieCatalog.Api.Tests/SmartMovieCatalog.Api.Tests.csproj --filter "FullyQualifiedName~ListMoviesEndpointTests"
- dotnet test backend/tests/SmartMovieCatalog.Infrastructure.Tests/SmartMovieCatalog.Infrastructure.Tests.csproj --filter "FullyQualifiedName~EfMovieRepositoryTests"
- npm test -- --watch=false (frontend)
- npm run build (frontend)

## Notes
- left unrelated local changes in `specs/017-home-movie-cards/*` out of this PR scope
